### PR TITLE
fix: GUI WebSocket keeps old daemon alive during restart

### DIFF
--- a/gui/frontend/app.js
+++ b/gui/frontend/app.js
@@ -750,7 +750,7 @@ function connectWebSocket(port) {
       clearInterval(pollTimer);
       pollTimer = null;
     }
-    wsBackoff = 1000;
+    wsBackoff = 3000;
     setStatus('live');
     // Defensive: fetch summary via HTTP to ensure active models/providers
     // are populated even if the initial WS summary message is missed
@@ -816,7 +816,7 @@ async function fetchSummary() {
 // WebSocket state
 let ws = null;
 let pollTimer = null;
-let wsBackoff = 1000;
+let wsBackoff = 3000;  // was 1000 — gives daemon time to restart
 let reconnectTimer = null;
 const WS_MAX_BACKOFF = 30000;
 const WS_CONNECT_TIMEOUT = 5000;

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -300,8 +300,16 @@ export async function startDaemon(
     };
   }
 
-  // Check if port is already in use
+  // Determine effective port for port-wait logic
   const effectivePort = port ?? await getConfigPort() ?? 3456;
+
+  // Wait for port to be fully free (old worker may linger briefly after stop)
+  for (let i = 0; i < 20; i++) {
+    if (!(await isPortInUse(effectivePort))) break;
+    await new Promise(r => setTimeout(r, 100));
+  }
+
+  // Check if port is still in use after wait
   if (await isPortInUse(effectivePort)) {
     return {
       success: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { loadConfig } from "./config.js";
 import type { LogLevel } from "./logger.js";
 import { MetricsStore } from "./metrics.js";
 import { latencyTracker } from "./hedging.js";
-import { attachWebSocket } from "./ws.js";
+import { attachWebSocket, closeWebSocket } from "./ws.js";
 import { startMonitor } from "./monitor.js";
 
 // Read version from package.json at startup
@@ -328,6 +328,7 @@ async function main() {
         configWatcher.close();
         configWatcher = null;
       }
+      closeWebSocket();
       await handle.closeAgents();
       await removeWorkerPidFile();
       logStream.end();
@@ -390,6 +391,7 @@ async function main() {
   // Graceful shutdown
   const shutdown = async () => {
     console.log("\n  Shutting down...");
+    closeWebSocket();
     await handle.closeAgents();
     process.exit(0);
   };

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -182,3 +182,12 @@ export function broadcastStreamEvent(data: StreamEvent): void {
     });
   }
 }
+
+export function closeWebSocket(): void {
+  if (!wssInstance) return;
+  for (const client of wssInstance.clients) {
+    client.terminate();
+  }
+  wssInstance.close();
+  wssInstance = null;
+}


### PR DESCRIPTION
## Summary
- Fixes #37 — WebSocket connections from GUI kept the HTTP server alive during graceful shutdown, causing port conflicts on restart
- Added `closeWebSocket()` to forcefully terminate all WS clients before shutting down the server
- Added port availability wait loop (up to 2s) in `startDaemon` before spawning monitor
- Increased GUI WebSocket reconnection backoff from 1s to 3s to avoid racing with daemon restart

## Test plan
- [ ] Start daemon, open GUI app, restart daemon — verify no port conflict errors
- [ ] Verify GUI reconnects within ~3s after daemon restart
- [ ] Verify normal shutdown still works cleanly (no lingering processes)
- [ ] Run `npm test` to ensure no regressions