### PR TITLE
fix(daemon): address 6 review findings — CORS, body limits, shutdown, prompt cache, pkill, race tracking

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -350,6 +350,17 @@ async function main() {
         clearInterval((handle as any)._configPollInterval);
       }
       closeWebSocket();
+
+      // Drain in-flight requests — wait up to 10s for them to complete
+      const drainStart = Date.now();
+      const DRAIN_TIMEOUT_MS = 10_000;
+      while ((handle as any).getInFlightCount?.() > 0 && Date.now() - drainStart < DRAIN_TIMEOUT_MS) {
+        await new Promise(r => setTimeout(r, 200));
+      }
+      if ((handle as any).getInFlightCount?.() > 0) {
+        logger.warn('Shutdown: in-flight requests still pending, closing agents anyway');
+      }
+
       await handle.closeAgents();
       await removeWorkerPidFile();
       logStream.end();

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -87,7 +87,7 @@ export async function startMonitor(args: {
       } catch {
         // lsof not available or other error — try pkill as fallback
         try {
-          execFileSync("pkill", ["-f", "modelweaver.*dist/index.*--daemon"], { stdio: "ignore" });
+          execFileSync("pkill", ["-f", "node.*modelweaver.*--daemon"], { stdio: "ignore" });
           await new Promise((r) => setTimeout(r, 1000));
         } catch { /* pkill also failed */ }
       }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -344,8 +344,25 @@ function applyTargetedReplacements(
 
   if (!needsModel && !needsMaxTokensClamp && !needsMaxTokensAdd) return rawBody;
 
-  // max_tokens not in body at all — must add via JSON parse (structural change)
+  // max_tokens not in body at all — insert via targeted replacement to preserve prompt cache.
+  // Find the last top-level closing brace and insert before it.
+  // This avoids JSON.stringify which reorders keys and breaks cache breakpoints.
   if (needsMaxTokensAdd) {
+    const insert = `"max_tokens":${maxOutputTokens}`;
+    // Check if there's a trailing value before the closing brace to determine comma placement
+    const lastBraceIdx = rawBody.lastIndexOf('}');
+    if (lastBraceIdx > 0) {
+      const beforeBrace = rawBody.substring(0, lastBraceIdx).trimEnd();
+      const needsComma = beforeBrace.length > 0 && !beforeBrace.endsWith(',');
+      let result = rawBody.substring(0, lastBraceIdx).replace(/\s*$/, '') +
+        (needsComma ? ',' : '') + insert + '}';
+      // Also apply model replacement if needed
+      if (needsModel && entry.model) {
+        result = result.replace(MODEL_KEY_REGEX, `"model":"${entry.model}"`);
+      }
+      return result;
+    }
+    // Fallback to full stringify if body structure is unexpected
     const mutable = { ...parsed };
     if (entry.model) mutable.model = entry.model;
     mutable.max_tokens = maxOutputTokens;
@@ -750,7 +767,7 @@ async function raceProviders(
       if (pending.length === 0) break;
 
       const winner = await Promise.race(pending);
-      completed.add(races[winner.index] ?? races[0]);
+      completed.add(races[winner.index]);
 
       if (winner.response.status >= 200 && winner.response.status < 300) {
         // Drain/cancel in-flight loser response bodies BEFORE aborting shared controller

--- a/src/server.ts
+++ b/src/server.ts
@@ -375,14 +375,24 @@ export function createApp(initConfig: AppConfig, logLevel: LogLevel, metricsStor
     );
   });
 
-  // CORS for GUI (Tauri WebView has origin tauri://localhost)
+  // CORS for GUI — restrict to localhost origins
+  const ALLOWED_ORIGINS = [
+    'http://localhost',
+    'http://127.0.0.1',
+    'https://localhost',
+    'tauri://localhost',
+  ];
+
   app.use("/api/*", async (c, next) => {
-    c.header("Access-Control-Allow-Origin", "*");
+    const origin = c.req.header('Origin') || '';
+    const isAllowed = !origin || ALLOWED_ORIGINS.some(o => origin.startsWith(o));
+    c.header("Access-Control-Allow-Origin", isAllowed ? origin : '');
     await next();
   });
-  // Handle CORS preflight for API routes only (GUI needs CORS; proxy endpoint does not)
   app.options("/api/*", (c) => {
-    c.header("Access-Control-Allow-Origin", "*");
+    const origin = c.req.header('Origin') || '';
+    const isAllowed = !origin || ALLOWED_ORIGINS.some(o => origin.startsWith(o));
+    c.header("Access-Control-Allow-Origin", isAllowed ? origin : '');
     c.header("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
     c.header("Access-Control-Allow-Headers", "Content-Type, Authorization, anthropic-version, x-api-key");
     return c.body("", 200);
@@ -392,10 +402,14 @@ export function createApp(initConfig: AppConfig, logLevel: LogLevel, metricsStor
     const requestId = randomUUID();
 
     // Read raw body once, then parse — avoids double serialization
+    const MAX_BODY_SIZE = 10 * 1024 * 1024; // 10MB
     let body: { model?: string };
     let rawBody: string;
     try {
       rawBody = await c.req.text();
+      if (rawBody.length > MAX_BODY_SIZE) {
+        return anthropicError("invalid_request_error", `Request body exceeds maximum size of ${MAX_BODY_SIZE / 1024 / 1024}MB`, requestId);
+      }
       body = JSON.parse(rawBody);
     } catch {
       return anthropicError("invalid_request_error", "Invalid JSON body", requestId);
@@ -442,6 +456,7 @@ export function createApp(initConfig: AppConfig, logLevel: LogLevel, metricsStor
     // Forward with fallback chain
     let successfulProvider = "unknown";
     let result: FallbackResult;
+    inFlightCount++;
     try {
       result = await forwardWithFallback(
         config.providers,
@@ -474,6 +489,8 @@ export function createApp(initConfig: AppConfig, logLevel: LogLevel, metricsStor
         { type: "error", error: { type: "api_error", message: "Upstream request failed: " + errMsg } },
         502
       );
+    } finally {
+      inFlightCount--;
     }
 
     // Use the actualModel from the winning entry, not ctx.actualModel
@@ -587,9 +604,12 @@ export function createApp(initConfig: AppConfig, logLevel: LogLevel, metricsStor
     return c.json(status);
   });
 
+  let inFlightCount = 0;
+
   return {
     app,
     getConfig: () => config,
+    getInFlightCount: () => inFlightCount,
     setConfig: async (newConfig: AppConfig) => {
       // Build key → agent map from old config for reuse lookup
       const oldAgents = new Map<string, import("undici").Agent>();


### PR DESCRIPTION
## Summary

Thorough daemon code review identified 6 issues (0 critical, 4 low, 2 informational). This PR addresses all of them.

### Fixes

| # | Severity | Fix | Files |
|---|----------|-----|-------|
| 1 | Low | **Prompt cache preservation** — Insert `max_tokens` via targeted string replacement instead of `JSON.stringify` to avoid breaking Anthropic's position-sensitive cache breakpoints on primary attempts | `proxy.ts` |
| 2 | Low | **Race tracking** — Remove `?? races[0]` fallback that masked potential index tracking bugs in `raceProviders()` | `proxy.ts` |
| 3 | Low | **Graceful shutdown** — Track in-flight requests and drain them (up to 10s timeout) before closing undici agents | `index.ts`, `server.ts` |
| 4 | Low | **Body size limit** — Reject requests >10MB to prevent memory exhaustion | `server.ts` |
| 5 | Info | **CORS restriction** — Replace `Access-Control-Allow-Origin: *` with localhost-only allowlist | `server.ts` |
| 6 | Info | **pkill narrowing** — Tighten fallback regex to `node.*modelweaver.*--daemon` to avoid matching unrelated processes | `monitor.ts` |

## Test plan

- [ ] Verify daemon starts and proxies requests normally (`npx modelweaver stop && npx modelweaver order`)
- [ ] Verify CORS headers on `/api/*` routes reflect origin (not `*`)
- [ ] Verify large request (>10MB) is rejected with `invalid_request_error`
- [ ] Verify graceful shutdown waits for in-flight requests (check logs)
- [ ] Verify prompt cache is preserved when `max_tokens` is absent from body