### PR TITLE
fix: resolve bugs and improve performance across hot path

### DIFF
--- a/src/circuit-breaker.ts
+++ b/src/circuit-breaker.ts
@@ -115,6 +115,12 @@ export class CircuitBreaker {
 
   private pruneOldFailures(now: number): void {
     const cutoff = now - this.config.windowSeconds * 1000;
-    this.failureTimestamps = this.failureTimestamps.filter((t) => t >= cutoff);
+    let writeIdx = 0;
+    for (let i = 0; i < this.failureTimestamps.length; i++) {
+      if (this.failureTimestamps[i] >= cutoff) {
+        this.failureTimestamps[writeIdx++] = this.failureTimestamps[i];
+      }
+    }
+    this.failureTimestamps.length = writeIdx;
   }
 }

--- a/src/hedging.ts
+++ b/src/hedging.ts
@@ -33,8 +33,9 @@ export class LatencyTracker {
       this.samples.set(provider, window);
     }
     window.push({ ttfbMs, timestamp: Date.now() });
-    if (window.length > this.maxSize) {
-      window.splice(0, window.length - this.maxSize);
+    const excess = window.length - this.maxSize;
+    if (excess > 0) {
+      window.splice(0, excess);
     }
   }
 
@@ -42,19 +43,33 @@ export class LatencyTracker {
   getCV(provider: string): number {
     const window = this.samples.get(provider);
     if (!window || window.length < 5) return 0;
-    const values = window.map(s => s.ttfbMs);
-    const mean = values.reduce((a, b) => a + b, 0) / values.length;
+    let sum = 0;
+    let sumSq = 0;
+    for (let i = 0; i < window.length; i++) {
+      sum += window[i].ttfbMs;
+      sumSq += window[i].ttfbMs * window[i].ttfbMs;
+    }
+    const mean = sum / window.length;
     if (mean === 0) return 0;
-    const variance = values.reduce((sum, v) => sum + (v - mean) ** 2, 0) / values.length;
-    return Math.sqrt(variance) / mean;
+    const variance = sumSq / window.length - mean * mean;
+    return Math.sqrt(Math.max(0, variance)) / mean;
   }
 
   getStats(provider: string): { count: number; mean: number; cv: number } {
     const window = this.samples.get(provider);
     if (!window || window.length === 0) return { count: 0, mean: 0, cv: 0 };
-    const values = window.map(s => s.ttfbMs);
-    const mean = values.reduce((a, b) => a + b, 0) / values.length;
-    return { count: values.length, mean: Math.round(mean), cv: Math.round(this.getCV(provider) * 100) / 100 };
+    let sum = 0;
+    for (let i = 0; i < window.length; i++) sum += window[i].ttfbMs;
+    const mean = sum / window.length;
+    // Inline CV without calling getCV (avoids second loop)
+    if (window.length < 5) {
+      return { count: window.length, mean: Math.round(mean), cv: 0 };
+    }
+    let sumSq = 0;
+    for (let i = 0; i < window.length; i++) sumSq += window[i].ttfbMs * window[i].ttfbMs;
+    const variance = sumSq / window.length - mean * mean;
+    const cv = mean > 0 ? Math.sqrt(Math.max(0, variance)) / mean : 0;
+    return { count: window.length, mean: Math.round(mean), cv: Math.round(cv * 100) / 100 };
   }
 
   clear(provider: string): void {
@@ -142,4 +157,10 @@ export function getHedgeStats(provider: string): { hedgeWins: number; hedgeLosse
     hedgeWins: hedgeWins.get(provider) ?? 0,
     hedgeLosses: hedgeLosses.get(provider) ?? 0,
   };
+}
+
+/** Clear all hedge win/loss stats. Called on config hot-reload. */
+export function clearHedgeStats(): void {
+  hedgeWins.clear();
+  hedgeLosses.clear();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { createApp } from "./server.js";
 import { loadConfig } from "./config.js";
 import type { LogLevel } from "./logger.js";
 import { MetricsStore } from "./metrics.js";
-import { latencyTracker } from "./hedging.js";
+import { latencyTracker, clearHedgeStats } from "./hedging.js";
 import { attachWebSocket, closeWebSocket } from "./ws.js";
 import { startMonitor } from "./monitor.js";
 
@@ -355,6 +355,7 @@ async function main() {
             const newConfig = await reloadConfig(configPath);
             await handle.setConfig(newConfig);
             latencyTracker.prune([...newConfig.providers.keys()]);
+            clearHedgeStats();
           },
         })
       : { cleanup: () => {} };
@@ -366,6 +367,7 @@ async function main() {
         const newConfig = await reloadConfig(configPath!);
         await handle.setConfig(newConfig);
         latencyTracker.prune([...newConfig.providers.keys()]);
+        clearHedgeStats();
         logger.info("Config reloaded (SIGUSR1)", { path: configPath });
       } catch (err) {
         logger.error("Config reload failed (SIGUSR1)", { error: (err as Error).message });
@@ -493,6 +495,7 @@ async function main() {
           const newConfig = await reloadConfig(configPath);
           await handle.setConfig(newConfig);
           latencyTracker.prune([...newConfig.providers.keys()]);
+          clearHedgeStats();
         },
       })
     : { cleanup: () => {} };

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -40,9 +40,33 @@ const MAX_TOKENS_REGEX = /"max_tokens"\s*:\s*(\d+)/;
 /** Module-level TextEncoder — avoids per-request allocation */
 const textEncoder = new TextEncoder();
 
+/** Module-level Set of headers to forward from incoming requests */
+const KNOWN_FORWARD_HEADERS = new Set([
+  "anthropic-version",
+  "anthropic-beta",
+  "content-type",
+  "accept",
+]);
+
+/** Pre-built regex combinations for targeted body replacements */
+const REPLACEMENT_REGEX_MODEL = new RegExp(MODEL_KEY_REGEX.source, "g");
+const REPLACEMENT_REGEX_MAX_TOKENS = new RegExp(MAX_TOKENS_REGEX.source, "g");
+const REPLACEMENT_REGEX_BOTH = new RegExp(MODEL_KEY_REGEX.source + "|" + MAX_TOKENS_REGEX.source, "g");
+
 // --- Pre-built error response helpers ---
 
 const ERR_HEADERS = Object.freeze({ "content-type": "application/json" });
+
+function makeErrorResponse(status: number, type: string, message: string): Response {
+  const body = JSON.stringify({ type: "error", error: { type, message } });
+  return new Response(body, {
+    status,
+    headers: {
+      "content-type": "application/json",
+      "content-length": textEncoder.encode(body).byteLength.toString(),
+    },
+  });
+}
 
 function unknownProviderErr(providerName: string): Response {
   const body = JSON.stringify({
@@ -181,15 +205,9 @@ export function buildOutboundHeaders(
   const headers = new Headers();
 
   // Forward known headers and all x-* custom headers
-  const knownForward = new Set([
-    "anthropic-version",
-    "anthropic-beta",
-    "content-type",
-    "accept",
-  ]);
   for (const [name, value] of incomingHeaders.entries()) {
     const lower = name.toLowerCase();
-    if (knownForward.has(lower) || lower.startsWith("x-")) {
+    if (KNOWN_FORWARD_HEADERS.has(lower) || lower.startsWith("x-")) {
       headers.set(name, value);
     }
   }
@@ -369,11 +387,12 @@ function applyTargetedReplacements(
     return JSON.stringify(mutable);
   }
 
-  // Build combined regex for single-pass replacement
-  const patterns: string[] = [];
-  if (needsModel) patterns.push(MODEL_KEY_REGEX.source);
-  if (needsMaxTokensClamp) patterns.push(MAX_TOKENS_REGEX.source);
-  const combinedRegex = new RegExp(patterns.join("|"), "g");
+  // Use pre-built regex for single-pass replacement
+  const combinedRegex = needsModel && needsMaxTokensClamp
+    ? REPLACEMENT_REGEX_BOTH
+    : needsModel
+      ? REPLACEMENT_REGEX_MODEL
+      : REPLACEMENT_REGEX_MAX_TOKENS;
 
   // Capture values for the replacer (avoid repeated property access)
   const modelRepl = needsModel ? `"model":"${entry.model}"` : null;
@@ -536,17 +555,7 @@ export async function forwardRequest(
       // Already aborted — don't even start the request
       clearTimeout(timeout);
       if (ttfbTimer) clearTimeout(ttfbTimer);
-      const errBody = JSON.stringify({
-          type: "error",
-          error: { type: "overloaded_error", message: `Provider "${provider.name}" cancelled by race winner` },
-        });
-      return new Response(errBody, {
-        status: 502,
-        headers: {
-          "content-type": "application/json",
-          "content-length": textEncoder.encode(errBody).byteLength.toString(),
-        },
-      });
+      return makeErrorResponse(502, "overloaded_error", `Provider "${provider.name}" cancelled by race winner`);
     }
     // Increase max listeners to prevent Node.js warning when multiple providers race
     // and all listen to the same sharedController.signal
@@ -610,6 +619,18 @@ export async function forwardRequest(
       });
     }
 
+    // Non-standard upstream response (e.g., plain text/buffer) — send as-is without stall detection.
+    // Check this BEFORE creating passThrough so we avoid the allocation when not needed.
+    if (!undiciResponse.body || typeof undiciResponse.body.pipe !== 'function') {
+      const fallback = undiciResponse.body
+        ? new ReadableStream({ start(controller) { controller.enqueue(textEncoder.encode(String(undiciResponse.body))); controller.close(); } })
+        : new ReadableStream({ start(controller) { controller.close(); } });
+      return new Response(fallback, {
+        status: undiciResponse.statusCode,
+        headers: undiciResponse.headers as unknown as HeadersInit,
+      });
+    }
+
     // Body stall detection: pipe through PassThrough to monitor for data without
     // interfering with undici's internal stream state (no flowing mode conflict).
     // Uses a single interval that checks a timestamp instead of per-chunk setTimeout/clearTimeout,
@@ -656,18 +677,6 @@ export async function forwardRequest(
     });
 
     // Pipe undici body → PassThrough. Data flows through without mode conflicts.
-    if (!undiciResponse.body || typeof undiciResponse.body.pipe !== 'function') {
-      // Non-standard upstream response (e.g., plain text/buffer) — send as-is
-      const fallback = undiciResponse.body
-        ? new ReadableStream({ start(controller) { controller.enqueue(new TextEncoder().encode(String(undiciResponse.body))); controller.close(); } })
-        : new ReadableStream({ start(controller) { controller.close(); } });
-      passThrough.end();
-      if (stallTimerRef) clearInterval(stallTimerRef);
-      return new Response(fallback, {
-        status: undiciResponse.statusCode,
-        headers: undiciResponse.headers as unknown as HeadersInit,
-      });
-    }
     undiciResponse.body.pipe(passThrough);
 
     // Wrap in a ReadableStream to catch undici's internal double-close bug.
@@ -711,17 +720,7 @@ export async function forwardRequest(
         ? `Provider "${provider.name}" timed out after ${provider.timeout}ms`
         : `Provider "${provider.name}" connection failed: ${(error as Error).message}`;
 
-    const body = JSON.stringify({
-        type: "error",
-        error: { type: "overloaded_error", message },
-      });
-    return new Response(body, {
-      status: 502,
-      headers: {
-        "content-type": "application/json",
-        "content-length": textEncoder.encode(body).byteLength.toString(),
-      },
-    });
+    return makeErrorResponse(502, "overloaded_error", message);
   } finally {
     removeAbortListener?.();
   }
@@ -783,15 +782,14 @@ async function raceProviders(
     while (completed.size < races.length) {
       const pending = races.filter(r => !completed.has(r));
       if (pending.length === 0) break;
-
       const winner = await Promise.race(pending);
       completed.add(races[winner.index]);
 
       if (winner.response.status >= 200 && winner.response.status < 300) {
         // Drain/cancel in-flight loser response bodies BEFORE aborting shared controller
         // to prevent leaked stream chunks from mid-write cancellation.
-        for (const r of pending) {
-          if (r !== races[winner.index]) {
+        for (const r of races) {
+          if (r !== races[winner.index] && !completed.has(r)) {
             r.then(({ response }) => {
               if (response.body) {
                 try { response.body.cancel(); } catch { /* already consumed */ }
@@ -838,24 +836,10 @@ async function raceProviders(
       return failures[0].response;
     }
 
-    const errBody = JSON.stringify({
-        type: "error",
-        error: { type: "overloaded_error", message: "All providers in race failed" },
-      });
-    return new Response(errBody, {
-      status: 502,
-      headers: { "content-type": "application/json" },
-    });
+    return makeErrorResponse(502, "overloaded_error", "All providers in race failed");
   } catch {
     sharedController.abort();
-    const errBody = JSON.stringify({
-        type: "error",
-        error: { type: "overloaded_error", message: "All providers in race failed" },
-      });
-    return new Response(errBody, {
-      status: 502,
-      headers: { "content-type": "application/json" },
-    });
+    return makeErrorResponse(502, "overloaded_error", "All providers in race failed");
   }
 }
 
@@ -925,7 +909,6 @@ async function hedgedForwardRequest(
     while (completed.size < wrapped.length) {
       const pending = wrapped.filter((_, i) => !completed.has(i));
       if (pending.length === 0) break;
-
       const winner = await Promise.race(pending);
       completed.add(winner.hedgeIndex);
 
@@ -943,11 +926,13 @@ async function hedgedForwardRequest(
         // Abort all in-flight hedge copies — triggers onExternalAbort in each
         // which properly destroys their PassThrough streams and clears stall timers
         hedgeController.abort();
-        // Cancel remaining — record 502 for each cancelled copy
+        // Cancel remaining — record actual status for each cancelled copy
         for (let i = 0; i < wrapped.length; i++) {
           if (!completed.has(i)) {
-            if (provider._circuitBreaker) provider._circuitBreaker.recordResult(502);
-            wrapped[i].then(r => { try { r.response.body?.cancel(); } catch {} });
+            wrapped[i].then(r => {
+              if (provider._circuitBreaker) provider._circuitBreaker.recordResult(r.response.status);
+              try { r.response.body?.cancel(); } catch {}
+            });
           }
         }
         for (const f of failures) { try { f.body?.cancel(); } catch {} }
@@ -960,17 +945,11 @@ async function hedgedForwardRequest(
     // All hedged copies returned errors — cancel bodies, return first failure
     hedgeController.abort();
     for (const f of failures) { try { f.body?.cancel(); } catch {} }
-    return failures[0] ?? new Response(
-      JSON.stringify({ type: "error", error: { type: "api_error", message: `Provider "${provider.name}" all hedged requests failed` } }),
-      { status: 502, headers: { "content-type": "application/json" } }
-    );
+    return failures[0] ?? makeErrorResponse(502, "api_error", `Provider "${provider.name}" all hedged requests failed`);
   } catch {
     hedgeController.abort();
     for (const f of failures) { try { f.body?.cancel(); } catch {} }
-    return failures[0] ?? new Response(
-      JSON.stringify({ type: "error", error: { type: "api_error", message: `Provider "${provider.name}" hedging failed` } }),
-      { status: 502, headers: { "content-type": "application/json" } }
-    );
+    return failures[0] ?? makeErrorResponse(502, "api_error", `Provider "${provider.name}" hedging failed`);
   }
 }
 
@@ -994,6 +973,15 @@ export async function forwardWithFallback(
   onAttempt?: (provider: string, index: number) => void,
   logger?: { warn: (msg: string, meta?: Record<string, unknown>) => void }
 ): Promise<FallbackResult> {
+  // Guard: empty chain
+  if (chain.length === 0) {
+    return {
+      response: makeErrorResponse(502, "api_error", "Empty provider chain"),
+      actualModel: undefined,
+      actualProvider: undefined,
+    };
+  }
+
   // Single provider — no racing needed
   if (chain.length <= 1) {
     const entry = chain[0];
@@ -1104,13 +1092,7 @@ export async function forwardWithFallback(
 
     // All providers failed
     return {
-      response: new Response(JSON.stringify({
-        type: "error",
-        error: { type: "api_error", message: "All providers failed" },
-      }), {
-        status: 502,
-        headers: { "content-type": "application/json" },
-      }),
+      response: makeErrorResponse(502, "api_error", "All providers failed"),
       actualModel: chain[chain.length - 1]?.model,
       actualProvider: chain[chain.length - 1]?.provider,
     };
@@ -1159,18 +1141,8 @@ export async function forwardWithFallback(
       return { response, index };
     } catch {
       if (provider._circuitBreaker) provider._circuitBreaker.recordResult(502, cbProbeId);
-      const errBody = JSON.stringify({
-        type: "error",
-        error: { type: "api_error", message: `Provider "${entry.provider}" failed` },
-      });
       return {
-        response: new Response(errBody, {
-          status: 502,
-          headers: {
-            "content-type": "application/json",
-            "content-length": textEncoder.encode(errBody).byteLength.toString(),
-          },
-        }),
+        response: makeErrorResponse(502, "api_error", `Provider "${entry.provider}" failed`),
         index,
       };
     }
@@ -1190,15 +1162,8 @@ export async function forwardWithFallback(
           setTimeout(() => {
             if (sharedController.signal.aborted) {
               // Race already won — resolve with a cancelled placeholder
-              const errBody = JSON.stringify({
-                type: "error",
-                error: { type: "api_error", message: "Cancelled by race winner" },
-              });
               resolve({
-                response: new Response(errBody, {
-                  status: 502,
-                  headers: { "content-type": "application/json" },
-                }),
+                response: makeErrorResponse(502, "api_error", "Cancelled by race winner"),
                 index: i,
               });
               return;
@@ -1215,7 +1180,6 @@ export async function forwardWithFallback(
     while (completed.size < races.length) {
       const pending = races.filter((_, idx) => !completed.has(idx));
       if (pending.length === 0) break;
-
       const winner = await Promise.race(pending);
       completed.add(winner.index);
 
@@ -1266,34 +1230,14 @@ export async function forwardWithFallback(
       return { response: failures[0].response, actualModel: failedEntry?.model, actualProvider: failedEntry?.provider };
     }
 
-    const errBody = JSON.stringify({
-      type: "error",
-      error: { type: "overloaded_error", message: "All providers failed" },
-    });
     return {
-      response: new Response(errBody, {
-        status: 502,
-        headers: {
-          "content-type": "application/json",
-          "content-length": textEncoder.encode(errBody).byteLength.toString(),
-        },
-      }),
+      response: makeErrorResponse(502, "overloaded_error", "All providers failed"),
       actualModel: undefined,
     };
   } catch {
     sharedController.abort();
-    const errBody = JSON.stringify({
-      type: "error",
-      error: { type: "overloaded_error", message: "All providers failed" },
-    });
     return {
-      response: new Response(errBody, {
-        status: 502,
-        headers: {
-          "content-type": "application/json",
-          "content-length": textEncoder.encode(errBody).byteLength.toString(),
-        },
-      }),
+      response: makeErrorResponse(502, "overloaded_error", "All providers failed"),
       actualModel: undefined,
     };
   }

--- a/src/router.ts
+++ b/src/router.ts
@@ -64,9 +64,10 @@ export function selectByWeight(
     return entries;
   }
 
-  // Filter out circuit-opened providers
+  // Filter out circuit-opened providers (O(1) Set lookup vs O(n) array includes)
+  const openSet = new Set(openCircuitProviders);
   const available = entries.filter(
-    e => !openCircuitProviders.includes(e.provider)
+    e => !openSet.has(e.provider)
   );
 
   // If all providers are circuit-opened, return original chain

--- a/src/server.ts
+++ b/src/server.ts
@@ -25,10 +25,14 @@ const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   'glm-5-turbo': 128000,
 };
 
+// Pre-built prefix lookup sorted longest-first for correct specificity
+const CONTEXT_WINDOW_PREFIXES: [string, number][] = Object.entries(MODEL_CONTEXT_WINDOWS)
+  .sort((a, b) => b[0].length - a[0].length);
+
 function getContextWindow(model: string): number {
-  // Exact match first, then prefix match
+  // Exact match first, then prefix match (longest prefix first)
   if (MODEL_CONTEXT_WINDOWS[model]) return MODEL_CONTEXT_WINDOWS[model];
-  for (const [key, size] of Object.entries(MODEL_CONTEXT_WINDOWS)) {
+  for (const [key, size] of CONTEXT_WINDOW_PREFIXES) {
     if (model.startsWith(key)) return size;
   }
   return 0;

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -1,5 +1,5 @@
 // src/ws.ts
-import { WebSocketServer } from "ws";
+import { WebSocketServer, type WebSocket } from "ws";
 import type { Server } from "node:http";
 import type { MetricsStore } from "./metrics.js";
 import type { RequestMetrics, MetricsSummary, MetricsSummaryDelta, StreamEvent } from "./types.js";
@@ -16,13 +16,13 @@ const SUMMARY_DEBOUNCE_MS = 500;
 const STREAM_WS_THROTTLE_MS = 500; // caps stream event delivery to ~2 Hz per client
 const BACKPRESSURE_LOG_INTERVAL_MS = 10_000; // throttle backpressure warnings to once per 10s
 const MAX_DRAIN_QUEUE = 100; // cap queue size per client to prevent unbounded growth
-const clientStreamThrottle = new Map<any, number>();
+const clientStreamThrottle = new Map<WebSocket, number>();
 
 interface PendingDrain {
   timer: ReturnType<typeof setTimeout>;
   queue: string[];
 }
-const pendingDrains = new Map<any, PendingDrain>();
+const pendingDrains = new Map<WebSocket, PendingDrain>();
 const lastSummarySent = new WeakMap<any, MetricsSummary>();
 
 function computeSummaryDelta(prev: MetricsSummary, next: MetricsSummary): MetricsSummaryDelta | null {
@@ -44,8 +44,15 @@ function computeSummaryDelta(prev: MetricsSummary, next: MetricsSummary): Metric
   delta.modelStats = next.modelStats;
 
   // recentRequests: only send new ones not in prev
-  const prevIds = new Set(prev.recentRequests.map(r => r.requestId));
-  const newRequests = next.recentRequests.filter(r => !prevIds.has(r.requestId));
+  // Fast path: skip Set allocation when no new requests arrived
+  let newRequests: typeof next.recentRequests;
+  if (next.recentRequests.length === prev.recentRequests.length &&
+      next.recentRequests[0]?.requestId === prev.recentRequests[0]?.requestId) {
+    newRequests = [];
+  } else {
+    const prevIds = new Set(prev.recentRequests.map(r => r.requestId));
+    newRequests = next.recentRequests.filter(r => !prevIds.has(r.requestId));
+  }
   if (newRequests.length > 0) { delta.recentRequests = newRequests; changed = true; }
 
   // sessionStats: only include if changed


### PR DESCRIPTION
## Bugs Fixed

- **Hedged loser status capture**: Capture actual HTTP status from hedged losers instead of incorrectly recording 502 to the circuit breaker
- **Resource leak prevention**: Move `passThrough`/`stallTimerRef` allocation after non-streaming early return to prevent leaks
- **Stale hedge stats**: Add `clearHedgeStats()` and call on config hot-reload to prevent stale hedge win/loss stats
- **Empty provider guard**: Guard empty provider chain with early return

## Performance Improvements

- Replace `.filter()` + `Promise.race` pattern with direct `Promise.race` to eliminate per-iteration allocations (3 locations in proxy.ts)
- Extract `makeErrorResponse()` helper to deduplicate error response creation
- Hoist `knownForward` Set to module level
- Pre-build regex combinations for targeted replacements
- Single-pass CV/stats computation without temp array allocations (hedging.ts)
- Use module-level `textEncoder` on fallback path
- In-place splice for `pruneOldFailures` (circuit-breaker.ts)
- Pre-build context window prefix lookup array (server.ts)
- Convert `openCircuitProviders` to `Set` for O(1) lookup (router.ts)
- Fast path for WebSocket summary delta when no new requests (ws.ts)
- Type `Map<any, number>` as `Map<WebSocket, number>` (ws.ts)