### PR TITLE
feat(config): make hedging and timing params configurable in config.yaml

### DIFF
--- a/modelweaver.example.yaml
+++ b/modelweaver.example.yaml
@@ -2,6 +2,12 @@
 # Run 'npx modelweaver init' to auto-configure this file AND
 # ~/.claude/settings.json for seamless Claude Code integration.
 
+# Hedging and timing configuration
+hedging:
+  speculativeDelay: 1000   # ms before starting backup providers (lower = faster fallback)
+  cvThreshold: 0.5         # latency variance threshold for multi-copy hedging
+  maxHedge: 4              # max concurrent copies per request
+
 server:
   port: 3456
   host: localhost

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,7 @@ import { parse as parseYaml } from "yaml";
 import { z } from "zod";
 import { Agent } from "undici";
 import { CircuitBreaker } from "./circuit-breaker.js";
-import type { AppConfig, ProviderConfig, RoutingEntry, ServerConfig } from "./types.js";
+import type { AppConfig, HedgingConfig, ProviderConfig, RoutingEntry, ServerConfig } from "./types.js";
 
 // --- Zod schemas for raw (pre-resolution) config ---
 
@@ -40,6 +40,15 @@ const routingEntrySchema = z.object({
   weight: z.number().positive().optional(),
 });
 
+const hedgingSchema = z.object({
+  /** Delay (ms) before starting backup providers in staggered race */
+  speculativeDelay: z.number().int().positive().default(1000),
+  /** Coefficient of variation threshold — hedging activates when CV >= this */
+  cvThreshold: z.number().min(0).max(10).default(0.5),
+  /** Maximum number of hedged copies per request */
+  maxHedge: z.number().int().min(1).max(10).default(4),
+});
+
 const rawConfigSchema = z.object({
   server: z
     .object({
@@ -51,6 +60,7 @@ const rawConfigSchema = z.object({
   routing: z.record(z.string(), z.array(routingEntrySchema)).default({}),
   tierPatterns: z.record(z.string(), z.array(z.string())).default({}),
   modelRouting: z.record(z.string(), z.array(routingEntrySchema)).default({}),
+  hedging: hedgingSchema.optional(),
 });
 
 // --- Env var resolution ---
@@ -291,7 +301,18 @@ export async function loadConfig(configPath?: string, cwd?: string): Promise<{ c
     host: validated.server.host,
   };
 
-  const config: AppConfig = { server, providers, routing, tierPatterns, modelRouting };
+  const config: AppConfig = {
+    server,
+    providers,
+    routing,
+    tierPatterns,
+    modelRouting,
+    hedging: validated.hedging ? {
+      speculativeDelay: validated.hedging.speculativeDelay,
+      cvThreshold: validated.hedging.cvThreshold,
+      maxHedge: validated.hedging.maxHedge,
+    } : undefined,
+  };
   return { config, configPath: path };
 }
 

--- a/src/hedging.ts
+++ b/src/hedging.ts
@@ -108,14 +108,17 @@ export const inFlightCounter = new InFlightCounter();
  * Calibration note: production data shows glm/minimax have CV 1.5-4.0 (extreme tail variance),
  * so hedging is warranted. CV threshold of 0.5 prevents over-hedging on stable runs.
  */
-export function computeHedgingCount(provider: ProviderConfig): number {
+export function computeHedgingCount(
+  provider: ProviderConfig,
+  config?: { cvThreshold?: number; maxHedge?: number },
+): number {
   const cv = latencyTracker.getCV(provider.name);
   const inFlight = inFlightCounter.get(provider.name);
   const maxConcurrent = provider.concurrentLimit ?? 1;
   const available = Math.max(1, maxConcurrent - inFlight);
 
-  const cvThreshold = 0.5;
-  const maxHedge = 4;
+  const cvThreshold = config?.cvThreshold ?? 0.5;
+  const maxHedge = config?.maxHedge ?? 4;
 
   if (cv < cvThreshold) return 1;
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,5 @@
 // src/proxy.ts
-import type { ProviderConfig, RoutingEntry, RequestContext } from "./types.js";
+import type { HedgingConfig, ProviderConfig, RoutingEntry, RequestContext } from "./types.js";
 import { request as undiciRequest } from "undici";
 import { PassThrough } from "node:stream";
 import fs from "node:fs";
@@ -74,8 +74,8 @@ function providerFailedErr(providerName: string): Response {
   return new Response(body, { status: 502, headers: ERR_HEADERS });
 }
 
-/** Delay (ms) before starting backup providers in staggered race */
-const SPECULATIVE_DELAY = 2000;
+/** Default delay (ms) before starting backup providers in staggered race */
+const DEFAULT_SPECULATIVE_DELAY = 1000;
 
 export function isRetriable(status: number): boolean {
   return status === 429 || status >= 500;
@@ -870,9 +870,10 @@ async function hedgedForwardRequest(
   incomingRequest: Request,
   chainSignal: AbortSignal | undefined,
   index: number,
-  logger?: { warn: (msg: string, meta?: Record<string, unknown>) => void }
+  logger?: { warn: (msg: string, meta?: Record<string, unknown>) => void },
+  hedging?: HedgingConfig,
 ): Promise<Response> {
-  const count = ctx.hasDistribution ? 1 : computeHedgingCount(provider);
+  const count = ctx.hasDistribution ? 1 : computeHedgingCount(provider, hedging);
 
   if (count <= 1) {
     // No hedging — single request
@@ -992,7 +993,8 @@ export async function forwardWithFallback(
   ctx: RequestContext,
   incomingRequest: Request,
   onAttempt?: (provider: string, index: number) => void,
-  logger?: { warn: (msg: string, meta?: Record<string, unknown>) => void }
+  logger?: { warn: (msg: string, meta?: Record<string, unknown>) => void },
+  hedging?: HedgingConfig,
 ): Promise<FallbackResult> {
   // Single provider — no racing needed
   if (chain.length <= 1) {
@@ -1013,7 +1015,7 @@ export async function forwardWithFallback(
 
     onAttempt?.(entry.provider, 0);
 
-    const response = await hedgedForwardRequest(provider, entry, ctx, incomingRequest, undefined, 0, logger);
+    const response = await hedgedForwardRequest(provider, entry, ctx, incomingRequest, undefined, 0, logger, hedging);
 
     return { response, actualModel: entry.model, actualProvider: entry.provider };
   }
@@ -1051,7 +1053,7 @@ export async function forwardWithFallback(
 
       try {
         const response = await hedgedForwardRequest(
-          provider, entry, ctx, incomingRequest, undefined, i, logger,
+          provider, entry, ctx, incomingRequest, undefined, i, logger, hedging,
         );
 
         if (provider._circuitBreaker) provider._circuitBreaker.recordResult(response.status, cbProbeId);
@@ -1155,6 +1157,7 @@ export async function forwardWithFallback(
         sharedController.signal,
         index,
         logger,
+        hedging,
       );
       return { response, index };
     } catch {
@@ -1204,7 +1207,7 @@ export async function forwardWithFallback(
               return;
             }
             attemptProvider(i).then(resolve);
-          }, SPECULATIVE_DELAY);
+          }, hedging?.speculativeDelay ?? DEFAULT_SPECULATIVE_DELAY);
         }),
       );
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -479,7 +479,8 @@ export function createApp(initConfig: AppConfig, logLevel: LogLevel, metricsStor
           // an onSuccess callback in proxy.ts (handled separately).
           if (!successfulProvider) successfulProvider = provider;
         },
-        logger
+        logger,
+        config.hedging,
       );
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,15 @@ export interface RoutingEntry {
   weight?: number;
 }
 
+export interface HedgingConfig {
+  /** Delay (ms) before starting backup providers in staggered race */
+  speculativeDelay: number;
+  /** Coefficient of variation threshold — hedging activates when CV >= this */
+  cvThreshold: number;
+  /** Maximum number of hedged copies per request */
+  maxHedge: number;
+}
+
 export interface ServerConfig {
   port: number;
   host: string;
@@ -41,6 +50,7 @@ export interface AppConfig {
   routing: Map<string, RoutingEntry[]>;
   tierPatterns: Map<string, string[]>;
   modelRouting: Map<string, RoutingEntry[]>;
+  hedging?: HedgingConfig;
 }
 
 export interface RequestContext {


### PR DESCRIPTION
## Summary
- Add top-level hedging section to config.yaml
- speculativeDelay: ms before starting backup providers (default 1000ms, down from hardcoded 2000ms)
- cvThreshold: latency variance threshold for multi-copy hedging (default 0.5)
- maxHedge: max concurrent copies per request (default 4)
- All parameters optional with sensible defaults
- Update modelweaver.example.yaml with new section

## Test plan
- npm run build passes
- Existing tests pass
- Verified hedging params flow from config through server -> proxy -> hedging