### PR TITLE
fix: improve daemon reliability — stall handling, timeout tuning, path resolution

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -20,9 +20,9 @@ const providerSchema = z.object({
     "baseUrl must use http:// or https://"
   ),
   apiKey: z.string().min(1, "apiKey is required"),
-  timeout: z.number().positive().default(30000),
-  ttfbTimeout: z.number().positive().default(15000),
-  stallTimeout: z.number().positive().default(30000),
+  timeout: z.number().positive().default(20000),
+  ttfbTimeout: z.number().positive().default(8000),
+  stallTimeout: z.number().positive().default(15000),
   authType: z.enum(["anthropic", "bearer"]).default("anthropic"),
   modelLimits: modelLimitsSchema,
   concurrentLimit: z.number().int().min(1).optional(),
@@ -42,7 +42,7 @@ const routingEntrySchema = z.object({
 
 const hedgingSchema = z.object({
   /** Delay (ms) before starting backup providers in staggered race */
-  speculativeDelay: z.number().int().positive().default(1000),
+  speculativeDelay: z.number().int().positive().default(500),
   /** Coefficient of variation threshold — hedging activates when CV >= this */
   cvThreshold: z.number().min(0).max(10).default(0.5),
   /** Maximum number of hedged copies per request */

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -2,8 +2,7 @@
 import { spawn, execFile, execFileSync } from "node:child_process";
 import { access, readFile, writeFile, unlink, mkdir } from "node:fs/promises";
 import { join } from "node:path";
-import { dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { resolveEntryScript } from "./entry-path.js";
 import { createServer } from "node:net";
 
 function isWindows(): boolean {
@@ -319,10 +318,7 @@ export async function startDaemon(
   }
 
   // Resolve the entry script path
-  const __filename = fileURLToPath(import.meta.url);
-  const __dirname = dirname(__filename);
-  // Use dist/index.js (built output) — works with both npx and direct node
-  const entryScript = join(__dirname, "index.js");
+  const entryScript = resolveEntryScript();
 
   // Build args — spawn a monitor process; monitor spawns the actual daemon child
   const childArgs: string[] = [entryScript, "--monitor"];

--- a/src/entry-path.ts
+++ b/src/entry-path.ts
@@ -1,0 +1,12 @@
+// src/entry-path.ts — Robust entry script resolution for bundled environments.
+// tsup code-splits into chunks, so import.meta.url may point to e.g. dist/daemon-*.js
+// instead of dist/index.js. process.argv[1] always holds the actual entry point.
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export function resolveEntryScript(): string {
+  // process.argv[1] is always the actual script Node was invoked with
+  if (process.argv[1]) return process.argv[1];
+  // Fallback: resolve relative to this module (works in dist/ layout)
+  return join(dirname(fileURLToPath(import.meta.url)), "index.js");
+}

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -1,8 +1,7 @@
 // src/monitor.ts — Monitor mode: spawns daemon child, auto-restarts on crash
 import { spawn } from "node:child_process";
 import { existsSync, unlinkSync } from "node:fs";
-import { dirname, join as pathJoin } from "node:path";
-import { fileURLToPath } from "node:url";
+import { resolveEntryScript } from "./entry-path.js";
 import { writePidFile, removePidFile, removeWorkerPidFile, getPidPath } from "./daemon.js";
 
 export async function startMonitor(args: {
@@ -18,7 +17,7 @@ export async function startMonitor(args: {
   }
   await writePidFile(process.pid);
 
-  const entryScript = pathJoin(dirname(fileURLToPath(import.meta.url)), "index.js");
+  const entryScript = resolveEntryScript();
 
   // Prevent monitor from crashing on unexpected errors
   process.on("uncaughtException", (err) => {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -8,6 +8,27 @@ import os from "node:os";
 import { latencyTracker, inFlightCounter, computeHedgingCount, recordHedgeWin, recordHedgeLosses } from './hedging.js';
 import { broadcastStreamEvent } from './ws.js';
 
+// --- Per-provider latency metrics ---
+const providerLatencySamples: Map<string, number[]> = new Map();
+const LATENCY_SAMPLE_THRESHOLD = 100;
+
+export function recordProviderLatency(providerName: string, latencyMs: number): void {
+  let samples = providerLatencySamples.get(providerName);
+  if (!samples) {
+    samples = [];
+    providerLatencySamples.set(providerName, samples);
+  }
+  samples.push(latencyMs);
+  if (samples.length >= LATENCY_SAMPLE_THRESHOLD) {
+    samples.sort((a, b) => a - b);
+    const p50 = samples[Math.floor(samples.length * 0.5)];
+    const p95 = samples[Math.floor(samples.length * 0.95)];
+    const p99 = samples[Math.floor(samples.length * 0.99)];
+    console.log(`[metrics] ${providerName} latency (n=${samples.length}): P50=${p50}ms P95=${p95}ms P99=${p99}ms`);
+    samples.length = 0; // reset
+  }
+}
+
 /**
  * Shallow-clone a parsed API request body just enough so that
  * cleanOrphanedToolMessages() can safely reassign body.messages
@@ -533,7 +554,7 @@ export async function forwardRequest(
   const timeout = setTimeout(() => controller.abort(), provider.timeout);
 
   // TTFB timeout: fail if no response headers received within ttfbTimeout ms
-  const ttfbTimeout = provider.ttfbTimeout ?? 15000;
+  const ttfbTimeout = provider.ttfbTimeout ?? 8000;
   let ttfbTimedOut = false;
   let ttfbTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -635,13 +656,15 @@ export async function forwardRequest(
     // interfering with undici's internal stream state (no flowing mode conflict).
     // Uses a single interval that checks a timestamp instead of per-chunk setTimeout/clearTimeout,
     // reducing syscall-level overhead on every data event.
-    const stallTimeout = provider.stallTimeout ?? 30000;
+    const stallTimeout = provider.stallTimeout ?? 15000;
     passThrough = new PassThrough();
 
     const stallMsg = `Body stalled: no data after ${stallTimeout}ms`;
     let lastDataTime = Date.now();
 
     const handleStall = () => {
+      provider._circuitBreaker?.recordResult(502);
+      console.warn(`[stall] Provider "${provider.name}" stalled: no data after ${stallTimeout}ms`);
       broadcastStreamEvent({
         requestId: ctx.requestId,
         model: String(ctx.actualModel ?? entry.model ?? ""),
@@ -660,7 +683,7 @@ export async function forwardRequest(
         stallTimerRef = undefined;
         handleStall();
       }
-    }, Math.min(stallTimeout / 4, 5000));
+    }, Math.min(stallTimeout / 8, 1000));
 
     // Monitor PassThrough for data events — just update timestamp (no timer churn)
     passThrough!.on("data", () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,7 @@
 // src/server.ts
 import { Hono } from "hono";
 import { resolveRequest, clearRoutingCache } from "./router.js";
-import { forwardWithFallback, type FallbackResult } from "./proxy.js";
+import { forwardWithFallback, type FallbackResult, recordProviderLatency } from "./proxy.js";
 import { createLogger, type LogLevel } from "./logger.js";
 import type { AppConfig, ProviderConfig, RequestContext } from "./types.js";
 import { randomUUID } from "node:crypto";
@@ -235,6 +235,9 @@ function createMetricsTransform(
         cacheCreationTokens: cacheCreation,
         sessionId: ctx.sessionId,
       });
+
+      // Record per-provider latency for percentile logging
+      recordProviderLatency(provider, latencyMs);
 
       // Broadcast completion event
       const contextWindow = getContextWindow(ctx.actualModel || ctx.model);

--- a/src/service-linux.ts
+++ b/src/service-linux.ts
@@ -1,7 +1,7 @@
 // src/service-linux.ts — Linux systemd user service management
 import { existsSync, unlinkSync, mkdirSync, writeFileSync } from "node:fs";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import { resolveEntryScript } from "./entry-path.js";
 import { homedir } from "node:os";
 import { execFileSync } from "node:child_process";
 
@@ -11,8 +11,7 @@ const SERVICE_DIR = join(homedir(), ".config", "systemd", "user");
 const SERVICE_PATH = join(SERVICE_DIR, "modelweaver.service");
 
 function getServiceContent(): string {
-  const __dirname = dirname(fileURLToPath(import.meta.url));
-  const entryScript = join(__dirname, "..", "dist", "index.js");
+  const entryScript = resolveEntryScript();
   const workDir = process.cwd();
 
   return `[Unit]

--- a/src/service-win32.ts
+++ b/src/service-win32.ts
@@ -1,7 +1,7 @@
 // src/service-win32.ts — Windows startup folder service management
 import { existsSync, unlinkSync, mkdirSync, writeFileSync } from "node:fs";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import { resolveEntryScript } from "./entry-path.js";
 
 export const platform = "win32";
 
@@ -16,8 +16,7 @@ const STARTUP_FOLDER = join(
 const VBS_PATH = join(STARTUP_FOLDER, "modelweaver.vbs");
 
 function getEntryScript(): string {
-  const __dirname = dirname(fileURLToPath(import.meta.url));
-  return join(__dirname, "..", "dist", "index.js");
+  return resolveEntryScript();
 }
 
 function getVbsContent(): string {


### PR DESCRIPTION
## Summary

Production log analysis (45hrs, 2,677 requests) revealed 6 improvement areas:

- **39 body-stall events** with zero circuit breaker awareness or fallback
- **P99 latency 27.5s / max 90s** from compounding timeouts
- **stderr `dist/dist/` crashes** from broken `import.meta.url` path resolution
- **No per-provider latency observability**

## Changes

| # | Fix | Files |
|---|---|---|
| 1 | Feed stalls into circuit breaker (record 502) | `src/proxy.ts` |
| 2 | Lower stall check interval 5s → 1s | `src/proxy.ts` |
| 3 | Tighten defaults: timeout 30s→20s, ttfb 15s→8s, stall 30s→15s, speculativeDelay 1s→500ms | `src/config.ts`, `src/proxy.ts` |
| 4 | Fix `dist/dist/` path bug with `resolveEntryScript()` using `process.argv[1]` | `src/entry-path.ts` (new), `src/daemon.ts`, `src/monitor.ts`, `src/service-linux.ts`, `src/service-win32.ts` |
| 5 | Add provider name to stall logs | `src/proxy.ts` |
| 6 | Per-provider P50/P95/P99 latency metrics (every 100 requests) | `src/proxy.ts`, `src/server.ts` |

## Test plan

- [x] `npm run build` — compiles clean
- [x] `npx vitest run` — 389/390 pass (1 pre-existing flaky init test)
- [x] `npx modelweaver stop && npx modelweaver start` — daemon starts clean, no new stderr errors