### PR TITLE
fix: prune providerLatencySamples on config hot-reload

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { loadConfig } from "./config.js";
 import type { LogLevel } from "./logger.js";
 import { MetricsStore } from "./metrics.js";
 import { latencyTracker, clearHedgeStats } from "./hedging.js";
+import { pruneProviderLatencySamples } from "./proxy.js";
 import { attachWebSocket, closeWebSocket } from "./ws.js";
 import { startMonitor } from "./monitor.js";
 
@@ -355,6 +356,7 @@ async function main() {
             const newConfig = await reloadConfig(configPath);
             await handle.setConfig(newConfig);
             latencyTracker.prune([...newConfig.providers.keys()]);
+            pruneProviderLatencySamples([...newConfig.providers.keys()]);
             clearHedgeStats();
           },
         })
@@ -367,6 +369,7 @@ async function main() {
         const newConfig = await reloadConfig(configPath!);
         await handle.setConfig(newConfig);
         latencyTracker.prune([...newConfig.providers.keys()]);
+        pruneProviderLatencySamples([...newConfig.providers.keys()]);
         clearHedgeStats();
         logger.info("Config reloaded (SIGUSR1)", { path: configPath });
       } catch (err) {
@@ -495,6 +498,7 @@ async function main() {
           const newConfig = await reloadConfig(configPath);
           await handle.setConfig(newConfig);
           latencyTracker.prune([...newConfig.providers.keys()]);
+          pruneProviderLatencySamples([...newConfig.providers.keys()]);
           clearHedgeStats();
         },
       })

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -29,6 +29,15 @@ export function recordProviderLatency(providerName: string, latencyMs: number): 
   }
 }
 
+export function pruneProviderLatencySamples(activeProviders: string[]): void {
+  const active = new Set(activeProviders);
+  for (const name of providerLatencySamples.keys()) {
+    if (!active.has(name)) {
+      providerLatencySamples.delete(name);
+    }
+  }
+}
+
 /**
  * Shallow-clone a parsed API request body just enough so that
  * cleanOrphanedToolMessages() can safely reassign body.messages


### PR DESCRIPTION
## Summary
- **Fix memory leak**: `providerLatencySamples` Map in `proxy.ts` was never pruned when config hot-reloaded, causing unbounded memory growth
- **New function**: `pruneProviderLatencySamples(activeProviders[])` — called alongside `latencyTracker.prune()` and `clearHedgeStats()` in all 3 config reload paths (file watcher, SIGUSR1, foreground watcher)

## Test plan
- [x] `npm run build` — clean (19ms)
- [x] `npx vitest run` — 390/390 pass