### PR TITLE
fix: resolve minor bugs from code review

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -125,7 +125,10 @@ function providerFailedErr(providerName: string): Response {
     type: "error",
     error: { type: "api_error", message: `Provider "${providerName}" failed` },
   });
-  return new Response(body, { status: 502, headers: ERR_HEADERS });
+  return new Response(body, {
+    status: 502,
+    headers: { ...ERR_HEADERS, "content-length": String(textEncoder.encode(body).byteLength) },
+  });
 }
 
 /** Default delay (ms) before starting backup providers in staggered race */

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,7 +9,7 @@ import { gzip } from "node:zlib";
 import { promisify } from "node:util";
 
 import type { MetricsStore } from "./metrics.js";
-import { latencyTracker, inFlightCounter, getHedgeStats } from "./hedging.js";
+import { latencyTracker, inFlightCounter, getHedgeStats, clearHedgeStats } from "./hedging.js";
 import { broadcastStreamEvent } from "./ws.js";
 import type { StreamEvent } from "./types.js";
 
@@ -687,6 +687,7 @@ export function createApp(initConfig: AppConfig, logLevel: LogLevel, metricsStor
 
       config = newConfig;
       clearRoutingCache();
+      clearHedgeStats();
       await Promise.all(closePromises);
     },
     closeAgents: async () => {

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -187,6 +187,7 @@ export function attachWebSocket(server: Server, metricsStore: MetricsStore): voi
       clearInterval(pingTimer);
       if (pendingSummaryTimer) clearTimeout(pendingSummaryTimer);
       lastSummarySent.delete(ws);
+      clientStreamThrottle.delete(ws);
       const pending = pendingDrains.get(ws);
       if (pending) {
         clearTimeout(pending.timer);


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- **Bug 1** (`src/proxy.ts`): `providerFailedErr` now includes `content-length` header, matching the other error functions (`unknownProviderErr`, `circuitBreakerErr`)
- **Bug 2** (`src/ws.ts`): `cleanup` inside `attachWebSocket()` now calls `clientStreamThrottle.delete(ws)` to prevent memory leaks on WebSocket disconnect
- **Bug 3** (`src/server.ts`): `setConfig()` now calls `clearHedgeStats()` alongside `clearRoutingCache()` to prevent hedge Wins/losses maps from growing indefinitely on config hot-reload

## Test plan
- [x] `npm run build` passes
- [x] `npx vitest run` (195 tests) passes
EOF
)