### PR TITLE
fix: critical bugs — ring buffer, CORS, WS reconnect

### DIFF
--- a/gui/frontend/app.js
+++ b/gui/frontend/app.js
@@ -707,6 +707,11 @@ function handleStreamEvent(data) {
 
 function connectWebSocket(port) {
   if (ws && ws.readyState === WebSocket.OPEN) return;
+  // Clear any pending reconnect timer from a previous close event
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
   // Close stale sockets stuck in CONNECTING or CLOSING state
   if (ws) {
     ws.close();

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -205,7 +205,7 @@ export class MetricsStore {
     // Group entries by actualModel || model
     const groups = new Map<string, RequestMetrics[]>();
     for (let i = 0; i < this.count; i++) {
-      const index = (i) % this.maxSize;
+      const index = ((this.head - this.count + i) % this.maxSize + this.maxSize) % this.maxSize;
       const entry = this.buffer[index];
       if (entry === null) continue;
       const key = entry.actualModel || entry.model;

--- a/src/server.ts
+++ b/src/server.ts
@@ -397,13 +397,13 @@ export function createApp(initConfig: AppConfig, logLevel: LogLevel, metricsStor
 
   app.use("/api/*", async (c, next) => {
     const origin = c.req.header('Origin') || '';
-    const isAllowed = !origin || ALLOWED_ORIGINS.some(o => origin.startsWith(o));
+    const isAllowed = !origin || ALLOWED_ORIGINS.includes(origin) || ALLOWED_ORIGINS.some(o => origin.startsWith(o + ':'));
     c.header("Access-Control-Allow-Origin", isAllowed ? origin : '');
     await next();
   });
   app.options("/api/*", (c) => {
     const origin = c.req.header('Origin') || '';
-    const isAllowed = !origin || ALLOWED_ORIGINS.some(o => origin.startsWith(o));
+    const isAllowed = !origin || ALLOWED_ORIGINS.includes(origin) || ALLOWED_ORIGINS.some(o => origin.startsWith(o + ':'));
     c.header("Access-Control-Allow-Origin", isAllowed ? origin : '');
     c.header("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
     c.header("Access-Control-Allow-Headers", "Content-Type, Authorization, anthropic-version, x-api-key");


### PR DESCRIPTION
## Summary
- **Ring buffer iteration** (`metrics.ts`): `getModelStats()` iterated buffer entries from index 0 regardless of `head` position, returning stale/wrong data. Fixed to use the same head-based indexing as `getRecentRequests()`.
- **CORS origin bypass** (`server.ts`): `origin.startsWith(o)` allowed `http://localhost.evil.com` to pass. Fixed by checking `origin.startsWith(o + ':')` so only proper port-delimited origins match (e.g. `http://localhost:8080` not `http://localhost.evil.com`). Applied to both the middleware and OPTIONS handler.
- **WS reconnect timer leak** (`gui/frontend/app.js`): `connectWebSocket()` never cleared the `reconnectTimer` before scheduling a new one, causing double reconnect scheduling after close events. Fixed by clearing any pending reconnect timer at function entry.

## Test plan
- [x] `npm run build` succeeds
- [x] `npx vitest run` — 390 tests pass