### PR TITLE
fix: resolve 5 bugs - ring buffer, swap vs move, CORS bypass, hedge abort, WS timer

### DIFF
--- a/gui/frontend/app.js
+++ b/gui/frontend/app.js
@@ -707,6 +707,11 @@ function handleStreamEvent(data) {
 
 function connectWebSocket(port) {
   if (ws && ws.readyState === WebSocket.OPEN) return;
+  // Clear any pending reconnect timer from a previous close event
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
   // Close stale sockets stuck in CONNECTING or CLOSING state
   if (ws) {
     ws.close();

--- a/src/init/screens/fallback.ts
+++ b/src/init/screens/fallback.ts
@@ -142,11 +142,10 @@ async function editChain(
 
         const toIdx = await promptSelect('Move to which position?', toChoices);
 
-        // Swap
-        const temp = entries[fromIdx];
-        entries[fromIdx] = entries[toIdx];
-        entries[toIdx] = temp;
-        check('Entries swapped.');
+        // Move
+        const [moved] = entries.splice(fromIdx, 1);
+        entries.splice(toIdx, 0, moved);
+        check('Entry moved.');
         break;
       }
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -205,7 +205,7 @@ export class MetricsStore {
     // Group entries by actualModel || model
     const groups = new Map<string, RequestMetrics[]>();
     for (let i = 0; i < this.count; i++) {
-      const index = (i) % this.maxSize;
+      const index = ((this.head - this.count + i) % this.maxSize + this.maxSize) % this.maxSize;
       const entry = this.buffer[index];
       if (entry === null) continue;
       const key = entry.actualModel || entry.model;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -870,9 +870,14 @@ async function hedgedForwardRequest(
     hedgeController.abort();
     for (const f of failures) { try { f.body?.cancel(); } catch {} }
     return failures[0] ?? makeErrorResponse(502, "api_error", `Provider "${provider.name}" all hedged requests failed`);
-  } catch {
+  } catch (err) {
     hedgeController.abort();
     for (const f of failures) { try { f.body?.cancel(); } catch {} }
+    // If the error is an AbortError from hedge cancellation (winner found or chain cancelled),
+    // return 499 instead of 502 to avoid false circuit breaker trips
+    if (err instanceof Error && err.name === 'AbortError') {
+      return makeErrorResponse(499, "api_error", `Provider "${provider.name}" hedging aborted`);
+    }
     return failures[0] ?? makeErrorResponse(502, "api_error", `Provider "${provider.name}" hedging failed`);
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -397,13 +397,13 @@ export function createApp(initConfig: AppConfig, logLevel: LogLevel, metricsStor
 
   app.use("/api/*", async (c, next) => {
     const origin = c.req.header('Origin') || '';
-    const isAllowed = !origin || ALLOWED_ORIGINS.some(o => origin.startsWith(o));
+    const isAllowed = !origin || ALLOWED_ORIGINS.includes(origin) || ALLOWED_ORIGINS.some(o => origin.startsWith(o + ':'));
     c.header("Access-Control-Allow-Origin", isAllowed ? origin : '');
     await next();
   });
   app.options("/api/*", (c) => {
     const origin = c.req.header('Origin') || '';
-    const isAllowed = !origin || ALLOWED_ORIGINS.some(o => origin.startsWith(o));
+    const isAllowed = !origin || ALLOWED_ORIGINS.includes(origin) || ALLOWED_ORIGINS.some(o => origin.startsWith(o + ':'));
     c.header("Access-Control-Allow-Origin", isAllowed ? origin : '');
     c.header("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
     c.header("Access-Control-Allow-Headers", "Content-Type, Authorization, anthropic-version, x-api-key");


### PR DESCRIPTION
## Summary

Fixes 5 bugs identified across the codebase:

1. **metrics.ts ring buffer iteration (CRITICAL - data corruption)**: `getModelStats()` used `(i) % maxSize` which reads wrong indices after the buffer wraps. Fixed with head-based indexing matching `getRecentRequests()`.

2. **fallback.ts reorder performs swap not move**: The reorder function swapped entries instead of moving them. Changed to splice-based move for correct positional reordering.

3. **server.ts CORS origin bypass (security)**: `origin.startsWith(o)` allowed bypass via `http://localhost.evil.com`. Fixed to use exact match (`includes`) or port-suffix check (`startsWith(o + ':')`).

4. **proxy.ts hedge abort causes false 502 circuit breaker hits**: When `hedgeController.abort()` cancelled in-flight copies after a winner was found, AbortError bubbled up to the catch block which returned 502. Fixed to detect AbortError and return 499 instead.

5. **app.js WS reconnect timer not cleared (memory leak)**: `connectWebSocket()` did not clear `reconnectTimer` before scheduling a new one, causing stale timer accumulation. Fixed by clearing timer at function entry.

## Test plan

- [x] `npm run build` succeeds
- [x] All 390 tests pass
- [ ] Manual verification of CORS headers with edge-case origins
- [ ] Verify hedging metrics don't show false 502s for cancelled copies