### PR TITLE
fix: circuit breaker and proxy reliability improvements

### DIFF
--- a/src/circuit-breaker.ts
+++ b/src/circuit-breaker.ts
@@ -26,6 +26,9 @@ export class CircuitBreaker {
   private halfOpenInProgress: boolean = false;
   private halfOpenProbeId: number | null = null;
   private nextProbeId: number = 0;
+  /** Synchronous lock: prevents concurrent half-open probe grants in the same microtask batch.
+   *  Set synchronously in canProceed() before any await, reset in recordResult(). */
+  private _probeGranted: boolean = false;
   private readonly config: BreakerConfig;
 
   constructor(config: Partial<BreakerConfig> = {}) {
@@ -46,15 +49,17 @@ export class CircuitBreaker {
         const probeId = this.nextProbeId++;
         this.halfOpenInProgress = true;
         this.halfOpenProbeId = probeId;
+        this._probeGranted = true;
         return { allowed: true, probeId };
       }
       return { allowed: false, probeId: 0 };
     }
     // half-open: allow exactly one probe at a time
-    if (!this.halfOpenInProgress) {
+    if (!this.halfOpenInProgress && !this._probeGranted) {
       const probeId = this.nextProbeId++;
       this.halfOpenInProgress = true;
       this.halfOpenProbeId = probeId;
+      this._probeGranted = true;
       return { allowed: true, probeId };
     }
     return { allowed: false, probeId: 0 };
@@ -65,6 +70,7 @@ export class CircuitBreaker {
     if (this.halfOpenInProgress && (probeId === undefined || probeId === this.halfOpenProbeId)) {
       this.halfOpenInProgress = false;
       this.halfOpenProbeId = null;
+      this._probeGranted = false;
     }
 
     if (status >= 200 && status < 300) {
@@ -72,6 +78,7 @@ export class CircuitBreaker {
       this.state = "closed";
       this.failureTimestamps = [];
       this.openedAt = null;
+      this._probeGranted = false;
       console.warn('[circuit-breaker] CLOSED — recovered after successful request');
       return;
     }
@@ -87,6 +94,7 @@ export class CircuitBreaker {
       // Any failure in half-open → back to open
       this.state = "open";
       this.openedAt = now;
+      this._probeGranted = false;
       console.warn('[circuit-breaker] back to OPEN — probe failed');
       return;
     }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -141,14 +141,11 @@ function isContextWindowError(status: number, body: string): boolean {
 function handleContextWindowError(status: number, body: string): Response | null {
   if (!isContextWindowError(status, body)) return null;
 
-  console.warn('[context-compact] Upstream context window limit detected');
-  try {
-    const flagDir = path.join(os.homedir(), '.claude', 'state');
-    fs.mkdirSync(flagDir, { recursive: true });
-    fs.writeFileSync(path.join(flagDir, 'context-compact-needed'), Date.now().toString());
-  } catch {
-    // Best-effort flag write
-  }
+  // Fire-and-forget async I/O to avoid blocking the event loop on the hot path.
+  // Only triggers on 400/413 context window errors (rare path).
+  fs.promises.mkdir(path.join(os.homedir(), '.claude', 'state'), { recursive: true })
+    .then(() => fs.promises.writeFile(path.join(os.homedir(), '.claude', 'state', 'context-compact-needed'), Date.now().toString()))
+    .catch(() => { /* best-effort */ });
 
   const enhanced = JSON.stringify({
     type: "error",
@@ -862,6 +859,10 @@ async function hedgedForwardRequest(
         for (let i = 0; i < wrapped.length; i++) {
           if (!completed.has(i)) {
             wrapped[i].then(r => {
+              // Skip 499 — these are synthetic responses from hedge cancellation
+              // (hedgeController.abort()), not real upstream failures. Recording
+              // them would inflate circuit breaker failure counts.
+              if (r.response.status === 499) return;
               if (provider._circuitBreaker) provider._circuitBreaker.recordResult(r.response.status);
               try { r.response.body?.cancel(); } catch {}
             });
@@ -1124,6 +1125,12 @@ export async function forwardWithFallback(
 
       if (winner.response.status >= 200 && winner.response.status < 300) {
         sharedController.abort();
+        // Record winner's result for circuit breaker (mirrors distribution path pattern)
+        const winningEntry = chain[winner.index];
+        const winningProvider = winningEntry ? providers.get(winningEntry.provider) : undefined;
+        if (winningProvider?._circuitBreaker) {
+          winningProvider._circuitBreaker.recordResult(winner.response.status);
+        }
         for (const f of failures) {
           try {
             f.response.body?.cancel();
@@ -1131,8 +1138,6 @@ export async function forwardWithFallback(
             /* ignore */
           }
         }
-        // Return the winning entry's model, not ctx.actualModel which may be overwritten
-        const winningEntry = chain[winner.index];
         return { response: winner.response, actualModel: winningEntry?.model, actualProvider: winningEntry?.provider };
       }
 


### PR DESCRIPTION
## Summary

Four reliability fixes from the daemon code review (rating 8.5/10):

- **C-1** (circuit-breaker): Add `_probeGranted` synchronous lock to prevent concurrent half-open probe grants in the same microtask batch
- **I-1** (proxy): Skip recording synthetic `499` (hedge cancellation) as circuit breaker failures — prevents premature circuit opening under high hedge rates
- **I-2** (proxy): Record `recordResult()` for race winner in non-distribution staggered race path — was missing vs distribution path which already had it
- **I-3** (proxy): Replace blocking `fs.mkdirSync`/`fs.writeFileSync` in `handleContextWindowError` with async fire-and-forget

## Test plan

- [x] `npm run build` passes
- [x] All 206 tests pass (13 test files)
- [x] Review findings I-1, I-2, I-3, C-1 addressed

## Review context

Full review at #77. Most actionable items were in `proxy.ts` and `circuit-breaker.ts` relating to circuit breaker integration with the hedging/racing subsystem.