### PR TITLE
feat(wizard): add concurrentLimit, windowSeconds, stallTimeout, poolSize to provider edit

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -217,7 +217,7 @@ export function findConfigFile(cwd: string = process.cwd(), { skipGlobal = false
  *  Used by init wizard to show existing providers and offer add/edit. */
 export function peekConfig(
   cwd?: string,
-): { configPath: string; providers: Map<string, { baseUrl: string; envKey: string; authType: "anthropic" | "bearer"; timeout: number; ttfbTimeout?: number; circuitBreaker?: { threshold?: number; cooldown?: number } }>; server: { port: number; host: string } | null; modelRouting: Map<string, { provider: string; model: string; weight?: number }[]> } | null {
+): { configPath: string; providers: Map<string, { baseUrl: string; envKey: string; authType: "anthropic" | "bearer"; timeout: number; ttfbTimeout?: number; concurrentLimit?: number; stallTimeout?: number; poolSize?: number; circuitBreaker?: { threshold?: number; windowSeconds?: number; cooldown?: number } }>; server: { port: number; host: string } | null; modelRouting: Map<string, { provider: string; model: string; weight?: number }[]> } | null {
   const configPath = findConfigFile(cwd);
   if (!configPath) return null;
 
@@ -225,7 +225,7 @@ export function peekConfig(
   const parsed = parseYaml(raw) as Record<string, unknown>;
   const providersRaw = (parsed?.providers ?? {}) as Record<string, Record<string, unknown>>;
 
-  const providers = new Map<string, { baseUrl: string; envKey: string; authType: "anthropic" | "bearer"; timeout: number; ttfbTimeout?: number; circuitBreaker?: { threshold?: number; cooldown?: number } }>();
+  const providers = new Map<string, { baseUrl: string; envKey: string; authType: "anthropic" | "bearer"; timeout: number; ttfbTimeout?: number; concurrentLimit?: number; stallTimeout?: number; poolSize?: number; circuitBreaker?: { threshold?: number; windowSeconds?: number; cooldown?: number } }>();
 
   for (const [id, config] of Object.entries(providersRaw)) {
     const apiKey = String(config.apiKey ?? "");
@@ -236,6 +236,7 @@ export function peekConfig(
     const cbRaw = config.circuitBreaker as Record<string, unknown> | undefined;
     const circuitBreaker = cbRaw ? {
       threshold: cbRaw.failureThreshold !== undefined ? Number(cbRaw.failureThreshold) : undefined,
+      windowSeconds: cbRaw.windowSeconds !== undefined ? Number(cbRaw.windowSeconds) : undefined,
       cooldown: cbRaw.cooldownSeconds !== undefined ? Number(cbRaw.cooldownSeconds) : undefined,
     } : undefined;
 
@@ -245,6 +246,9 @@ export function peekConfig(
       authType: String(config.authType ?? "anthropic") as "anthropic" | "bearer",
       timeout: Number(config.timeout ?? 30000),
       ttfbTimeout: config.ttfbTimeout !== undefined ? Number(config.ttfbTimeout) : undefined,
+      concurrentLimit: config.concurrentLimit !== undefined ? Number(config.concurrentLimit) : undefined,
+      stallTimeout: config.stallTimeout !== undefined ? Number(config.stallTimeout) : undefined,
+      poolSize: config.poolSize !== undefined ? Number(config.poolSize) : undefined,
       circuitBreaker,
     });
   }

--- a/src/init.ts
+++ b/src/init.ts
@@ -92,10 +92,14 @@ function buildStateFromConfig(): WizardState {
       envKey: provider.envKey,
       apiKey: process.env[provider.envKey] ?? '',
       timeout: provider.timeout,
-      ttfbTimeout: provider.ttfbTimeout ?? 15000,
+      ttfbTimeout: provider.ttfbTimeout ?? 8000,
       authType: provider.authType,
+      concurrentLimit: provider.concurrentLimit ?? 3,
+      stallTimeout: provider.stallTimeout ?? 15000,
+      poolSize: provider.poolSize ?? 10,
       circuitBreaker: {
         threshold: provider.circuitBreaker?.threshold ?? 5,
+        windowSeconds: provider.circuitBreaker?.windowSeconds ?? 120,
         cooldown: provider.circuitBreaker?.cooldown ?? 60,
       },
     });

--- a/src/init/screens/providers.ts
+++ b/src/init/screens/providers.ts
@@ -146,19 +146,27 @@ export async function addProvider(state: WizardState): Promise<ScreenAction> {
   const apiKey = (await promptPassword('API key')).trim();
   if (!apiKey) throw new GoBackError();
 
-  const timeout = await promptNumber('Request timeout (ms)', 60000);
+  const timeout = await promptNumber('Request timeout (ms)', 20000);
   if (timeout <= 0) {
     fail('Timeout must be greater than 0');
     return { type: 'error', message: 'Timeout must be greater than 0' };
   }
 
-  const ttfbTimeout = await promptNumber('TTFB timeout (ms)', 30000);
+  const ttfbTimeout = await promptNumber('TTFB timeout (ms)', 8000);
   if (ttfbTimeout >= timeout) {
     fail(`Warning: TTFB timeout (${ttfbTimeout}ms) should be less than total timeout (${timeout}ms). Proceeding anyway.`);
     // Non-blocking warning — continue with the values
   }
-  const threshold = await promptNumber('Circuit breaker threshold', 3);
+  const threshold = await promptNumber('Circuit breaker failure threshold', 3);
+  const windowSeconds = await promptNumber('Circuit breaker window (s)', 120);
+  if (windowSeconds < 1) { fail('Window must be at least 1 second'); return { type: 'error', message: 'Window must be at least 1 second' }; }
   const cooldown = await promptNumber('Circuit breaker cooldown (s)', 60);
+  const concurrentLimit = await promptNumber('Concurrent limit', 3);
+  if (concurrentLimit < 1) { fail('Concurrent limit must be at least 1'); return { type: 'error', message: 'Concurrent limit must be at least 1' }; }
+  const stallTimeout = await promptNumber('Stall timeout (ms)', 15000);
+  if (stallTimeout <= 0) { fail('Stall timeout must be positive'); return { type: 'error', message: 'Stall timeout must be positive' }; }
+  const poolSize = await promptNumber('Connection pool size', 10);
+  if (poolSize < 1) { fail('Pool size must be at least 1'); return { type: 'error', message: 'Pool size must be at least 1' }; }
 
   // Determine auth type from baseUrl matching
   const preset = matchPreset(baseUrl);
@@ -171,8 +179,12 @@ export async function addProvider(state: WizardState): Promise<ScreenAction> {
     timeout,
     ttfbTimeout,
     authType: preset.authType,
+    concurrentLimit,
+    stallTimeout,
+    poolSize,
     circuitBreaker: {
       threshold,
+      windowSeconds,
       cooldown,
     },
   };
@@ -199,7 +211,11 @@ export async function editProvider(state: WizardState): Promise<ScreenAction> {
       boxLine('Timeout:', `${provider.timeout}ms`),
       boxLine('TTFB timeout:', `${provider.ttfbTimeout}ms`),
       boxLine('CB threshold:', `${provider.circuitBreaker.threshold}`),
+      boxLine('CB window:', `${provider.circuitBreaker.windowSeconds}s`),
       boxLine('CB cooldown:', `${provider.circuitBreaker.cooldown}s`),
+      boxLine('Concurrent limit:', `${provider.concurrentLimit ?? 3}`),
+      boxLine('Stall timeout:', `${provider.stallTimeout ?? 15000}ms`),
+      boxLine('Pool size:', String(provider.poolSize ?? 10)),
       boxLine('Auth type:', provider.authType),
       '',
       '  Select field to edit:',
@@ -213,7 +229,11 @@ export async function editProvider(state: WizardState): Promise<ScreenAction> {
       { title: 'Timeout', value: 'timeout' },
       { title: 'TTFB timeout', value: 'ttfbTimeout' },
       { title: 'CB threshold', value: 'threshold' },
+      { title: 'CB window', value: 'window' },
       { title: 'CB cooldown', value: 'cooldown' },
+      { title: 'Concurrent limit', value: 'concurrentLimit' },
+      { title: 'Stall timeout', value: 'stallTimeout' },
+      { title: 'Pool size', value: 'poolSize' },
       { title: 'Back', value: 'back' },
     ]);
 
@@ -255,10 +275,50 @@ export async function editProvider(state: WizardState): Promise<ScreenAction> {
         check('Threshold updated.');
         break;
       }
+      case 'window': {
+        const val = await promptNumber('Circuit breaker window (s)', provider.circuitBreaker.windowSeconds ?? 120);
+        if (val < 1) {
+          fail('Window must be at least 1 second');
+          break;
+        }
+        provider.circuitBreaker.windowSeconds = val;
+        check('CB window updated.');
+        break;
+      }
       case 'cooldown': {
         const val = await promptNumber('Circuit breaker cooldown (s)', provider.circuitBreaker.cooldown);
         provider.circuitBreaker.cooldown = val;
         check('Cooldown updated.');
+        break;
+      }
+      case 'concurrentLimit': {
+        const val = await promptNumber('Concurrent limit', provider.concurrentLimit ?? 3);
+        if (val < 1) {
+          fail('Concurrent limit must be at least 1');
+          break;
+        }
+        provider.concurrentLimit = val;
+        check('Concurrent limit updated.');
+        break;
+      }
+      case 'stallTimeout': {
+        const val = await promptNumber('Stall timeout (ms)', provider.stallTimeout ?? 15000);
+        if (val <= 0) {
+          fail('Stall timeout must be positive');
+          break;
+        }
+        provider.stallTimeout = val;
+        check('Stall timeout updated.');
+        break;
+      }
+      case 'poolSize': {
+        const val = await promptNumber('Connection pool size', provider.poolSize ?? 10);
+        if (val < 1) {
+          fail('Pool size must be at least 1');
+          break;
+        }
+        provider.poolSize = val;
+        check('Pool size updated.');
         break;
       }
     }

--- a/src/init/screens/shared/types.ts
+++ b/src/init/screens/shared/types.ts
@@ -8,8 +8,12 @@ export interface WizardProvider {
   timeout: number;
   ttfbTimeout: number;
   authType: 'anthropic' | 'bearer';
+  concurrentLimit?: number;
+  stallTimeout?: number;
+  poolSize?: number;
   circuitBreaker: {
     threshold: number;
+    windowSeconds: number;
     cooldown: number;
   };
 }

--- a/src/init/screens/shared/write.ts
+++ b/src/init/screens/shared/write.ts
@@ -23,8 +23,12 @@ export function buildYamlConfig(state: WizardState): string {
       timeout: provider.timeout,
       ttfbTimeout: provider.ttfbTimeout,
       authType: provider.authType,
+      ...(provider.concurrentLimit != null && { concurrentLimit: provider.concurrentLimit }),
+      ...(provider.stallTimeout != null && { stallTimeout: provider.stallTimeout }),
+      ...(provider.poolSize != null && { poolSize: provider.poolSize }),
       circuitBreaker: {
         failureThreshold: provider.circuitBreaker.threshold,
+        windowSeconds: provider.circuitBreaker.windowSeconds,
         cooldownSeconds: provider.circuitBreaker.cooldown,
       },
     };


### PR DESCRIPTION
## Summary

Adds missing P1 and P3 provider fields to the wizard init CLI so they are no longer silently dropped when saving `config.yaml`:

- **P1**: `concurrentLimit` — provider concurrency cap (adds per-provider concurrency limit to add/edit flows)
- **P1**: `windowSeconds` — circuit breaker rolling window duration (adds to CB section in add/edit flows)
- **P3**: `stallTimeout` — stream stall detection timeout
- **P3**: `poolSize` — connection pool size

Also fixes:
- Missing bounds validation in `addProvider()` for all new fields (edit flow already validated)
- Optional fields now conditionally serialized in `buildYamlConfig()` (avoids `undefined`/`null` in YAML)
- Default value alignment with Zod schema: `timeout` → 20000, `ttfbTimeout` → 8000

## Test plan

- [ ] Run `npx modelweaver init` → add a provider → verify all new fields appear in the add flow prompts
- [ ] Edit an existing provider → verify "Concurrent limit", "CB window", "Stall timeout", "Pool size" appear as editable fields
- [ ] Save and reload → verify new fields are persisted in `config.yaml`
- [ ] Enter invalid values (e.g. concurrentLimit=0) → verify error message appears

Fixes #94.