### PR TITLE
fix(server): record metrics for error responses so GUI shows provider errors

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -604,6 +604,33 @@ export function createApp(initConfig: AppConfig, logLevel: LogLevel, metricsStor
           timestamp: Date.now(),
         });
       });
+    } else if (metricsStore && (response.status < 200 || response.status >= 400)) {
+      // Error / non-2xx responses — record metrics so provider error tracking
+      // picks them up (metricsStore.recordRequest → _providerErrors population).
+      // Without this, error responses were never recorded and the GUI showed 0 errors.
+      const errorProvider = successfulProvider || result.actualProvider || (ctx.providerChain[0]?.provider ?? "unknown");
+      const errorTarget = result.actualProvider || (ctx.providerChain.length > 0 ? ctx.providerChain[0].provider : errorProvider);
+      const latencyMs = Date.now() - ctx.startTime;
+
+      metricsStore.recordRequest({
+        requestId: ctx.requestId,
+        model: ctx.model,
+        actualModel: ctx.actualModel || ctx.model,
+        tier: ctx.tier,
+        provider: errorProvider,
+        targetProvider: errorTarget,
+        status: response.status,
+        inputTokens: 0,
+        outputTokens: 0,
+        latencyMs,
+        tokensPerSec: 0,
+        timestamp: Date.now(),
+        fallbackMode: ctx.fallbackMode,
+        sessionId: ctx.sessionId,
+      });
+
+      recordProviderLatency(errorProvider, latencyMs);
+      broadcastProviderHealth(buildProviderHealth(config, metricsStore));
     }
 
     // Add request ID to response (responses from fetch have immutable headers, so create new)


### PR DESCRIPTION
## Summary
- Error responses (4xx/5xx) were never recorded in `metricsStore` because `recordRequest()` only ran inside `createMetricsTransform()`, which was only instantiated for 2xx responses
- This caused `_providerErrors` to remain empty and the GUI to always show **0 errors** per provider
- Added an `else if` clause for non-2xx responses that calls `metricsStore.recordRequest()` with the error status, 0 tokens, and immediately broadcasts `providerHealth` so the GUI updates in real-time

## Root Cause
`server.ts:586` guarded `createMetricsTransform` with `status >= 200 && status < 300`. Error responses bypassed this entirely, so the error-tracking code at `metrics.ts:174` (`if (metrics.status < 200 || metrics.status >= 400)`) was never reached.

## Test plan
- [x] All 213 existing tests pass
- [ ] Manual: trigger a 429 or 502 from a provider → verify GUI shows error count > 0
- [ ] Manual: verify `provider_health` WS message includes `errorBreakdown` with status codes