### PR TITLE
feat(proxy): adaptive TTFB timeout based on observed provider latency

### DIFF
--- a/src/adaptive-timeout.ts
+++ b/src/adaptive-timeout.ts
@@ -1,0 +1,54 @@
+// src/adaptive-timeout.ts — Dynamic timeout adjustment based on observed latency
+
+import type { ProviderConfig } from "./types.js";
+import type { LatencyTracker } from "./hedging.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Minimum TTFB timeout (ms) — safety floor even for very fast providers */
+const TTFB_FLOOR_MS = 2000;
+
+/**
+ * Minimum sample count before adaptive tuning kicks in.
+ * With fewer samples, the statistics aren't meaningful enough to adjust.
+ */
+const MIN_SAMPLES = 5;
+
+// ---------------------------------------------------------------------------
+// Adaptive TTFB timeout
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve an adaptive TTFB timeout for a provider based on observed latency.
+ *
+ * Uses the LatencyTracker's rolling window (30 samples) to compute an
+ * approximate p95, then clamps it:
+ *   - Floor: TTFB_FLOOR_MS (2s) — prevents overly aggressive timeouts
+ *   - Ceiling: the configured static `ttfbTimeout` — user knows best
+ *
+ * This means adaptive tuning can only TIGHTEN the timeout, never loosen it.
+ * If a provider gets persistently slow, the circuit breaker handles it.
+ *
+ * Falls back to the static configured value when there aren't enough samples.
+ *
+ * @param provider - Provider config (reads `ttfbTimeout`)
+ * @param tracker - LatencyTracker instance from hedging module
+ * @returns TTFB timeout in milliseconds
+ */
+export function resolveAdaptiveTTFB(provider: ProviderConfig, tracker: LatencyTracker): number {
+  const base = provider.ttfbTimeout ?? 8000;
+  const stats = tracker.getStats(provider.name);
+
+  // Not enough data — use static config
+  if (stats.count < MIN_SAMPLES) return base;
+
+  // Approximate p95 using mean + 2*stddev (normal distribution).
+  // cv = stddev / mean, so stddev = cv * mean.
+  // p95 ≈ mean * (1 + 2*cv)
+  const p95Approx = Math.round(stats.mean * (1 + 2 * stats.cv));
+
+  // Clamp: floor safety, ceiling is the configured static value
+  return Math.max(TTFB_FLOOR_MS, Math.min(base, p95Approx));
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import os from "node:os";
 import { latencyTracker, inFlightCounter, computeHedgingCount, recordHedgeWin, recordHedgeLosses } from './hedging.js';
 import { warmupProvider } from './pool.js';
+import { resolveAdaptiveTTFB } from './adaptive-timeout.js';
 import { broadcastStreamEvent } from './ws.js';
 
 // --- Per-provider latency metrics ---
@@ -554,7 +555,7 @@ export async function forwardRequest(
   const timeout = setTimeout(() => controller.abort(), provider.timeout);
 
   // TTFB timeout: fail if no response headers received within ttfbTimeout ms
-  const ttfbTimeout = provider.ttfbTimeout ?? 8000;
+  const ttfbTimeout = resolveAdaptiveTTFB(provider, latencyTracker);
   let ttfbTimedOut = false;
   let ttfbTimer: ReturnType<typeof setTimeout> | null = null;
 

--- a/tests/adaptive-timeout.test.ts
+++ b/tests/adaptive-timeout.test.ts
@@ -1,0 +1,125 @@
+// tests/adaptive-timeout.test.ts
+import { describe, it, expect, afterEach } from "vitest";
+import { resolveAdaptiveTTFB } from "../src/adaptive-timeout.js";
+import { LatencyTracker } from "../src/hedging.js";
+import type { ProviderConfig } from "../src/types.js";
+
+function makeProvider(overrides: Partial<ProviderConfig> = {}): ProviderConfig {
+  return {
+    name: "test",
+    baseUrl: "http://localhost:9999",
+    apiKey: "test",
+    timeout: 20000,
+    ...overrides,
+  };
+}
+
+describe("resolveAdaptiveTTFB", () => {
+  const tracker = new LatencyTracker(30);
+
+  afterEach(() => {
+    tracker.clear("test");
+  });
+
+  it("returns static value when fewer than 5 samples", () => {
+    const provider = makeProvider({ ttfbTimeout: 8000 });
+
+    // Only 3 samples — not enough for adaptive
+    tracker.record("test", 1500);
+    tracker.record("test", 1600);
+    tracker.record("test", 1700);
+
+    const result = resolveAdaptiveTTFB(provider, tracker);
+    expect(result).toBe(8000); // falls back to static
+  });
+
+  it("returns adaptive (tightened) TTFB when provider is consistently fast", () => {
+    const provider = makeProvider({ ttfbTimeout: 8000 });
+
+    // Provider consistently responds in ~500ms with low variance
+    for (let i = 0; i < 10; i++) {
+      tracker.record("test", 450 + Math.floor(Math.random() * 100));
+    }
+
+    const result = resolveAdaptiveTTFB(provider, tracker);
+
+    // p95 approximation should be well below the static 8000
+    expect(result).toBeLessThan(8000);
+    // But should respect the floor of 2000ms
+    expect(result).toBeGreaterThanOrEqual(2000);
+    // Adaptive timeout should be the floor (p95 ≈ 600ms < 2000ms floor)
+    expect(result).toBe(2000);
+  });
+
+  it("never goes below 2000ms floor", () => {
+    const provider = makeProvider({ ttfbTimeout: 8000 });
+
+    // Extremely fast provider — all responses under 200ms
+    for (let i = 0; i < 10; i++) {
+      tracker.record("test", 100 + Math.floor(Math.random() * 50));
+    }
+
+    const result = resolveAdaptiveTTFB(provider, tracker);
+    expect(result).toBe(2000); // floor
+  });
+
+  it("never exceeds static configured value", () => {
+    const provider = makeProvider({ ttfbTimeout: 5000 });
+
+    // Provider with high variance — some slow responses
+    tracker.record("test", 1000);
+    tracker.record("test", 2000);
+    tracker.record("test", 3000);
+    tracker.record("test", 4000);
+    tracker.record("test", 5000);
+    tracker.record("test", 6000);
+    tracker.record("test", 7000);
+    tracker.record("test", 8000);
+    tracker.record("test", 9000);
+    tracker.record("test", 10000);
+
+    const result = resolveAdaptiveTTFB(provider, tracker);
+    expect(result).toBeLessThanOrEqual(5000); // capped at configured value
+  });
+
+  it("defaults to 8000ms when ttfbTimeout not configured", () => {
+    const provider = makeProvider({}); // no ttfbTimeout
+
+    // No samples at all
+    const result = resolveAdaptiveTTFB(provider, tracker);
+    expect(result).toBe(8000);
+  });
+
+  it("falls back to static when provider has no samples", () => {
+    const provider = makeProvider({ ttfbTimeout: 6000 });
+
+    const result = resolveAdaptiveTTFB(provider, tracker);
+    expect(result).toBe(6000);
+  });
+
+  it("adapts independently per provider", () => {
+    const fastProvider = makeProvider({ name: "fast", ttfbTimeout: 8000 });
+    const slowProvider = makeProvider({ name: "slow", ttfbTimeout: 10000 });
+
+    // Fast provider: ~300ms TTFB
+    for (let i = 0; i < 10; i++) {
+      tracker.record("fast", 250 + Math.floor(Math.random() * 100));
+    }
+    // Slow provider: ~2000ms TTFB
+    for (let i = 0; i < 10; i++) {
+      tracker.record("slow", 1800 + Math.floor(Math.random() * 400));
+    }
+
+    const fastTimeout = resolveAdaptiveTTFB(fastProvider, tracker);
+    const slowTimeout = resolveAdaptiveTTFB(slowProvider, tracker);
+
+    // Fast provider should have a tighter timeout
+    expect(fastTimeout).toBeLessThan(slowTimeout);
+    // Neither should exceed their configured static values
+    expect(fastTimeout).toBeLessThanOrEqual(8000);
+    expect(slowTimeout).toBeLessThanOrEqual(10000);
+
+    tracker.clear("fast");
+    tracker.clear("slow");
+  });
+});


### PR DESCRIPTION
## Summary
- Dynamically tightens TTFB timeout for consistently fast providers using LatencyTracker's rolling p95 estimate
- Can only reduce the configured static value, never exceed it — circuit breaker handles slow providers
- 3 files changed: new module, 1-line proxy integration, 7 tests

## Test plan
- [x] `npm run build` — compiles without errors
- [x] `npx vitest run` — 229 tests passed (14 files, 0 regressions)
- [x] Daemon smoke test — all providers healthy, `/api/pool` responding
- [ ] Manual: observe TTFB timeout tightening after 5+ requests to a fast provider

Closes #123