### PR TITLE
fix: suppress error→error StreamState warnings

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -183,7 +183,10 @@ const VALID_TRANSITIONS: Record<StreamState, StreamState[]> = {
   // stall error (e.g. from a race between TTFB timer and actual response), the
   // stream should resume rather than being permanently stuck in error state.
   // "error → complete" is also allowed for non-streaming error responses.
-  error: ["streaming", "ttfb", "complete"],
+  // "error → error" is a no-op — common when stall timer and catch block both
+  // fire for the same failure (stall handler runs first via setImmediate,
+  // then catch block also tries to set error).
+  error: ["streaming", "ttfb", "complete", "error"],
 };
 
 /**


### PR DESCRIPTION
## Summary
- Add `"error"` as a valid self-transition in `VALID_TRANSITIONS["error"]`
- Suppresses false `[StreamState] Invalid transition: error → error` warnings that fire when both the stall handler and catch block set error state for the same failure via `setImmediate`

## Context
The stall timer handler (`handleStall`) uses `setImmediate` to set `_streamState = "error"`. The `forwardRequest` catch block also uses `setImmediate` to do the same. Both fire for the same failure — the first one wins, the second triggers the warning since `"error"` was not in `VALID_TRANSITIONS["error"]`.

## Note on Issue #2 (staggered fallback delay)
The 1s stagger delay (`hedging.speculativeDelay`) is already configurable in `config.yaml` and does NOT affect distribution mode (sequential fallback with weights). It only applies to non-weighted routing's staggered race. No code change needed — already working as designed.