### PR TITLE
fix(proxy): prevent adaptive TTFB death spiral and accept circuit breaker config aliases

### DIFF
--- a/src/adaptive-timeout.ts
+++ b/src/adaptive-timeout.ts
@@ -2,7 +2,6 @@
 
 import type { ProviderConfig } from "./types.js";
 import type { LatencyTracker } from "./hedging.js";
-import { getHealthScore } from "./health-score.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -17,12 +16,6 @@ const TTFB_FLOOR_MS = 2000;
  */
 const MIN_SAMPLES = 5;
 
-/**
- * Minimum health score multiplier floor.
- * Even a very unhealthy provider (score → 0) gets at least 20% of configured TTFB.
- */
-const HEALTH_TTFB_MIN_MULTIPLIER = 0.2;
-
 // ---------------------------------------------------------------------------
 // Adaptive TTFB timeout
 // ---------------------------------------------------------------------------
@@ -30,16 +23,13 @@ const HEALTH_TTFB_MIN_MULTIPLIER = 0.2;
 /**
  * Resolve an adaptive TTFB timeout for a provider.
  *
- * Composes two independent signals via min():
- *   1. Latency-based: uses LatencyTracker's rolling window to compute approximate p95.
- *      Tightens timeout for consistently slow providers.
- *   2. Health-based: scales configured TTFB by max(healthScore, HEALTH_TTFB_MIN_MULTIPLIER).
- *      Fails unhealthy providers faster so the fallback chain can start sooner.
+ * Uses latency-based adaptation only: when a provider is consistently fast,
+ * the timeout is tightened to match observed p95 (capped at configured value).
+ * When insufficient data is available, falls back to the static configured value.
  *
- * Taking the min() of both signals means a provider gets fast-failed if it's
- * either slow OR unhealthy — whichever is more aggressive.
- *
- * Falls back to the static configured value when there aren't enough samples.
+ * Previously, a health-based signal shrank the timeout on unhealthy providers,
+ * creating a death spiral: unhealthy → shorter timeout → more failures → worse health.
+ * Health-based TTFB was removed because it prevented providers from recovering.
  *
  * @param provider - Provider config (reads `ttfbTimeout`)
  * @param tracker - LatencyTracker instance from hedging module
@@ -48,25 +38,17 @@ const HEALTH_TTFB_MIN_MULTIPLIER = 0.2;
 export function resolveAdaptiveTTFB(provider: ProviderConfig, tracker: LatencyTracker): number {
   const base = provider.ttfbTimeout ?? 8000;
 
-  // Signal 1: latency-based (from existing implementation)
+  // Latency-based signal: tighten timeout when observed p95 is below configured base.
+  // This helps fast providers fail bad connections sooner without penalizing slow ones.
   const stats = tracker.getStats(provider.name);
-  let latencyBased = base;
   if (stats.count >= MIN_SAMPLES) {
     // Approximate p95 using mean + 2*stddev (normal distribution).
     // cv = stddev / mean, so stddev = cv * mean.
     // p95 ≈ mean * (1 + 2*cv)
     const p95Approx = Math.round(stats.mean * (1 + 2 * stats.cv));
-    latencyBased = Math.max(TTFB_FLOOR_MS, Math.min(base, p95Approx));
+    return Math.max(TTFB_FLOOR_MS, Math.min(base, p95Approx));
   }
 
-  // Signal 2: health-score-based
-  // Scale TTFB by health score, floor at 20% of base to avoid too-aggressive timeouts.
-  // Provider at 100% health → full base
-  // Provider at 30% health → 30% of base (or HEALTH_TTFB_MIN_MULTIPLIER, whichever is higher)
-  const healthScore = getHealthScore(provider.name);
-  const healthMultiplier = Math.max(healthScore, HEALTH_TTFB_MIN_MULTIPLIER);
-  const healthBased = Math.round(base * healthMultiplier);
-
-  // Compose: use the tighter of the two signals
-  return Math.min(latencyBased, healthBased);
+  // Not enough samples — use configured value as-is
+  return base;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -137,9 +137,15 @@ const providerSchema = z.object({
   connectionRetries: z.number().int().min(0).max(10).optional(),
   circuitBreaker: z.object({
     failureThreshold: z.number().int().min(1).optional(),
+    threshold: z.number().int().min(1).optional(),
     windowSeconds: z.number().int().min(1).optional(),
     cooldownSeconds: z.number().int().min(1).optional(),
-  }).optional(),
+    cooldown: z.number().int().min(1).optional(),
+  }).transform((cb) => ({
+    failureThreshold: cb.failureThreshold ?? cb.threshold,
+    windowSeconds: cb.windowSeconds,
+    cooldownSeconds: cb.cooldownSeconds ?? cb.cooldown,
+  })).optional(),
 });
 
 const routingEntrySchema = z.object({
@@ -241,9 +247,9 @@ export function peekConfig(
     // Extract circuitBreaker config if present
     const cbRaw = config.circuitBreaker as Record<string, unknown> | undefined;
     const circuitBreaker = cbRaw ? {
-      threshold: cbRaw.failureThreshold !== undefined ? Number(cbRaw.failureThreshold) : undefined,
+      threshold: cbRaw.failureThreshold !== undefined ? Number(cbRaw.failureThreshold) : cbRaw.threshold !== undefined ? Number(cbRaw.threshold) : undefined,
       windowSeconds: cbRaw.windowSeconds !== undefined ? Number(cbRaw.windowSeconds) : undefined,
-      cooldown: cbRaw.cooldownSeconds !== undefined ? Number(cbRaw.cooldownSeconds) : undefined,
+      cooldown: cbRaw.cooldownSeconds !== undefined ? Number(cbRaw.cooldownSeconds) : cbRaw.cooldown !== undefined ? Number(cbRaw.cooldown) : undefined,
     } : undefined;
 
     providers.set(id, {

--- a/tests/adaptive-timeout.test.ts
+++ b/tests/adaptive-timeout.test.ts
@@ -1,8 +1,7 @@
 // tests/adaptive-timeout.test.ts
-import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { resolveAdaptiveTTFB } from "../src/adaptive-timeout.js";
 import { LatencyTracker } from "../src/hedging.js";
-import { recordHealthEvent, clearHealthScores } from "../src/health-score.js";
 import type { ProviderConfig } from "../src/types.js";
 
 function makeProvider(overrides: Partial<ProviderConfig> = {}): ProviderConfig {
@@ -125,71 +124,45 @@ describe("resolveAdaptiveTTFB", () => {
   });
 });
 
-describe("resolveAdaptiveTTFB — health score composition", () => {
+describe("resolveAdaptiveTTFB — health score no longer shrinks TTFB", () => {
   const tracker = new LatencyTracker(30);
 
-  beforeEach(() => {
-    clearHealthScores();
-  });
-
   afterEach(() => {
-    clearHealthScores();
     tracker.clear("test");
   });
 
-  it("reduces TTFB for unhealthy provider even with no latency data", () => {
-    const provider = makeProvider({ name: "sick", ttfbTimeout: 10000 });
+  it("returns configured TTFB when no latency data regardless of provider health", () => {
+    // Previously, an unhealthy provider would get a shortened TTFB.
+    // Now health score is ignored — only latency data matters.
+    const provider = makeProvider({ name: "sick", ttfbTimeout: 15000 });
 
-    // Make provider unhealthy (50% success rate)
-    for (let i = 0; i < 20; i++) {
-      recordHealthEvent("sick", i % 2 === 0, 300);
-    }
-
+    // No latency samples → should return configured value as-is
     const result = resolveAdaptiveTTFB(provider, tracker);
-    // No latency data → latency-based falls back to 10000
-    // Health-based: 0.5 × 10000 = 5000
-    // min(10000, 5000) = 5000
-    expect(result).toBeLessThanOrEqual(5000);
-    expect(result).toBeGreaterThan(0);
+    expect(result).toBe(15000);
   });
 
-  it("health score floor at 20% prevents too-aggressive timeout", () => {
-    const provider = makeProvider({ name: "dead", ttfbTimeout: 10000 });
+  it("latency-based adaptation still works for fast providers", () => {
+    const provider = makeProvider({ name: "fast", ttfbTimeout: 15000 });
 
-    // Make provider score near 0 (all failures)
-    for (let i = 0; i < 20; i++) {
-      recordHealthEvent("dead", false, 30000);
-    }
-
-    const result = resolveAdaptiveTTFB(provider, tracker);
-    // Health-based: max(0, 0.2) × 10000 = 2000 (floor)
-    // min(10000, 2000) = 2000
-    expect(result).toBe(2000);
-  });
-
-  it("takes min of latency-based and health-based signals", () => {
-    const provider = makeProvider({ name: "combo", ttfbTimeout: 10000 });
-
-    // Latency data: consistently ~300ms → latency-based = floor = 2000
+    // Consistently fast ~500ms TTFB
     for (let i = 0; i < 10; i++) {
-      tracker.record("combo", 300);
-    }
-
-    // Health data: 100% healthy → health-based = 10000 (full)
-    for (let i = 0; i < 10; i++) {
-      recordHealthEvent("combo", true, 300);
+      tracker.record("fast", 450 + Math.floor(Math.random() * 100));
     }
 
     const result = resolveAdaptiveTTFB(provider, tracker);
-    // Latency-based: 2000 (floor), Health-based: 10000 (full)
-    // min(2000, 10000) = 2000
-    expect(result).toBe(2000);
+    // p95 approximation should be well below configured 15000
+    expect(result).toBeLessThan(15000);
+    // But should respect the floor of 2000ms
+    expect(result).toBeGreaterThanOrEqual(2000);
+    expect(result).toBe(2000); // floor hit since p95 ≈ 600ms
+
+    tracker.clear("fast");
   });
 
-  it("healthy provider with no latency data uses static TTFB", () => {
-    const provider = makeProvider({ name: "healthy", ttfbTimeout: 15000 });
+  it("slow provider keeps full configured TTFB when no latency samples", () => {
+    const provider = makeProvider({ ttfbTimeout: 15000 });
 
-    // No latency data, no health data
+    // No samples at all — returns configured value
     const result = resolveAdaptiveTTFB(provider, tracker);
     expect(result).toBe(15000);
   });


### PR DESCRIPTION
## Summary

- **Remove health-based TTFB shrinking** — the adaptive timeout was scaling TTFB down by health score (e.g. 15000ms → 3000ms at 20% health), creating a death spiral where unhealthy providers could never recover
- **Accept alias circuit breaker config keys** — Zod schema now accepts both `threshold`/`failureThreshold` and `cooldown`/`cooldownSeconds` so user configs like `threshold: 2` actually take effect

## Root Cause

Two bugs compounding:
1. `resolveAdaptiveTTFB()` multiplied configured TTFB by health score with a 0.2 floor — so a struggling provider's 15s TTFB became 3s, guaranteeing more failures
2. Circuit breaker YAML keys (`threshold`, `cooldown`) didn't match Zod schema (`failureThreshold`, `cooldownSeconds`) — config was silently ignored, falling back to defaults

## Test plan

- [x] `tests/adaptive-timeout.test.ts` — 10/10 passing (health-based tests rewritten to verify TTFB is no longer shrunk)
- [x] `npm run build` — compiles clean
- [x] Daemon reloaded with `npx modelweaver reload` — new TTFB values will use configured 15000ms instead of degraded 3000ms
- [ ] Monitor daemon logs for next GLM requests — should show 15000ms TTFB, not 3000ms