### PR TITLE
feat(session): increase per-session connections to 3

### DIFF
--- a/src/session-pool.ts
+++ b/src/session-pool.ts
@@ -9,7 +9,7 @@ export interface SessionStats {
   providers: string[];
 }
 
-const SESSION_AGENT_CONNECTIONS = 1;
+const SESSION_AGENT_CONNECTIONS = 3; // Support parallel subagent streams per session
 const SESSION_KEEPALIVE_MS = 30_000;
 const SESSION_KEEPALIVE_MAX_MS = 60_000;
 const DEFAULT_SESSION_IDLE_TTL_MS = 600_000; // 10 minutes idle → close


### PR DESCRIPTION
## Summary

- Bump `SESSION_AGENT_CONNECTIONS` from 1 → 3 to support parallel subagent traffic
- Claude Code can fire multiple concurrent upstream requests via subagents; a single HTTP/2 connection could bottleneck during parallel agent workflows
- 3 connections per provider per session gives headroom for typical subagent concurrency (2-3 parallel calls)

## Test plan

- [x] `npx vitest run tests/session-pool.test.ts` — 8/8 pass
- [x] `npm run build` — clean
- [x] Daemon reloaded, `/api/sessions` returns correct stats
- [ ] Verify parallel subagent calls don't see connection排队