### PR TITLE
fix(server): update ActiveProbeManager providers on config hot-reload

### DIFF
--- a/src/health-probe.ts
+++ b/src/health-probe.ts
@@ -16,6 +16,11 @@ export class ActiveProbeManager {
     this.fetchFn = fetchFn;
   }
 
+  /** Update the providers reference after config hot-reload */
+  updateProviders(providers: Map<string, { baseUrl: string; _circuitBreaker?: CircuitBreaker }>): void {
+    this.providers = providers;
+  }
+
   start(intervalMs: number = PROBE_INTERVAL_MS): void {
     if (this.intervalId !== null) return; // already running
     this.intervalId = setInterval(() => { this.tick().catch(() => {}); }, intervalMs);

--- a/src/server.ts
+++ b/src/server.ts
@@ -845,6 +845,7 @@ export function createApp(initConfig: AppConfig, logLevel: LogLevel, metricsStor
 
       await Promise.all(closePromises);
       config = newConfig;
+      activeProbeManager.updateProviders(newConfig.providers);
       clearRoutingCache();
       clearHedgeStats();
     },


### PR DESCRIPTION
## Summary
- Add `updateProviders()` method to `ActiveProbeManager` to update its internal providers reference
- Call it from `setConfig()` after `config = newConfig`

## Problem
`ActiveProbeManager` is constructed once at `createApp()` time with the initial `config.providers` map. On config hot-reload, `setConfig()` updates the `config` variable but the manager still holds the old reference. Health probes continue pinging deleted providers and miss new ones.

## Test plan
- [x] 276/276 tests pass
- [x] Build clean

Closes #159