### PR TITLE
fix: call destroy() on shutdown and remove dead gui field

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,8 +30,8 @@ function setupGlobalExceptionHandlers(log: {
   });
 }
 
-function parseArgs(argv: string[]): { port?: number; config?: string; verbose: boolean; help: boolean; daemon: boolean; monitor: boolean; gui: boolean } {
-  const args: { port?: number; config?: string; verbose: boolean; help: boolean; daemon: boolean; monitor: boolean; gui: boolean } = { verbose: false, help: false, daemon: false, monitor: false, gui: false };
+function parseArgs(argv: string[]): { port?: number; config?: string; verbose: boolean; help: boolean; daemon: boolean; monitor: boolean } {
+  const args: { port?: number; config?: string; verbose: boolean; help: boolean; daemon: boolean; monitor: boolean } = { verbose: false, help: false, daemon: false, monitor: false };
   for (let i = 2; i < argv.length; i++) {
     switch (argv[i]) {
       case "-p":

--- a/src/server.ts
+++ b/src/server.ts
@@ -880,7 +880,7 @@ export function createApp(initConfig: AppConfig, logLevel: LogLevel, metricsStor
       clearHedgeStats();
     },
     closeSessionPool: async () => {
-      await sessionPool.closeAll();
+      await sessionPool.destroy();
     },
     getSessionPoolStats: () => sessionPool.getStats(),
     closeAgents: async () => {


### PR DESCRIPTION
## Summary

- **`src/server.ts`**: `closeSessionPool()` now calls `sessionPool.destroy()` instead of `sessionPool.closeAll()`. `destroy()` stops the 60s sweep timer before closing agents, preventing a race where the timer fires on cleared maps during shutdown.
- **`src/index.ts`**: Removed unused `gui` boolean from `parseArgs()` return type. The `gui` subcommand is handled directly via `process.argv[2] === 'gui'` (line 311), not through `parseArgs`.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [x] `node dist/index.js reload` — daemon reloaded
- [ ] Verify daemon shutdown completes cleanly (`node dist/index.js stop`) — no sweep timer errors in log

Closes #167, Closes #166