### PR TITLE
fix: floor setMaxListeners decrement to prevent negative values

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -758,7 +758,8 @@ export async function forwardRequest(
     externalSignal.addEventListener("abort", onExternalAbort, { once: true });
     removeAbortListener = () => {
       externalSignal.removeEventListener("abort", onExternalAbort);
-      (externalSignal as any).setMaxListeners?.((externalSignal as any).getMaxListeners?.() - 1);
+      const current = (externalSignal as any).getMaxListeners?.() ?? 10;
+      (externalSignal as any).setMaxListeners?.(Math.max(0, current - 1));
     };
   }
 


### PR DESCRIPTION
## Summary

- Floor `setMaxListeners` decrement at 0 to prevent negative values under concurrent traffic
- When multiple `forwardRequest` calls race on the same `externalSignal`, increment/decrement can go out of sync, causing the decrement path to produce negative values

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [x] `node dist/index.js reload` — daemon reloaded
- [ ] Run concurrent hedging traffic and verify no `MaxListenersExceededWarning` in logs

Closes #165