### PR TITLE
fix: update session pool TTL and stale threshold on config hot-reload

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,7 @@
 import { Hono } from "hono";
 import { resolveRequest, clearRoutingCache } from "./router.js";
 import { forwardWithFallback, setMetricsStore as setProxyMetricsStore, type FallbackResult, recordProviderLatency } from "./proxy.js";
-import { SessionAgentPool } from "./session-pool.js";
+import { SessionAgentPool, DEFAULT_STALE_AGENT_THRESHOLD_MS } from "./session-pool.js";
 import { createLogger, type LogLevel } from "./logger.js";
 import type { AppConfig, ProviderConfig, RequestContext, StreamState } from "./types.js";
 import { transitionStreamState } from "./types.js";
@@ -878,6 +878,14 @@ export function createApp(initConfig: AppConfig, logLevel: LogLevel, metricsStor
       activeProbeManager.updateProviders(newConfig.providers);
       clearRoutingCache();
       clearHedgeStats();
+
+      // Update session pool thresholds from new config
+      const newIdleTtl = newConfig.server?.sessionIdleTtlMs ?? 600_000;
+      const newProviderStaleMs = [...(newConfig.providers?.values() ?? [])]
+        .map(p => p._staleAgentThresholdMs)
+        .filter((v): v is number => v != null);
+      const newStaleMs = newProviderStaleMs.length > 0 ? Math.min(...newProviderStaleMs) : DEFAULT_STALE_AGENT_THRESHOLD_MS;
+      sessionPool.updateConfig(newIdleTtl, newStaleMs);
     },
     closeSessionPool: async () => {
       await sessionPool.destroy();

--- a/src/session-pool.ts
+++ b/src/session-pool.ts
@@ -20,7 +20,7 @@ const SWEEP_INTERVAL_MS = 60_000; // sweep every 60s
  * before the HTTP/2 PING could keep them alive. Raised to 30s to match
  * keepAliveTimeout — the PING frame (every 10s) keeps the connection alive.
  */
-const DEFAULT_STALE_AGENT_THRESHOLD_MS = 30_000;
+export const DEFAULT_STALE_AGENT_THRESHOLD_MS = 30_000;
 
 /**
  * Manages per-session per-model undici Agents.
@@ -38,8 +38,8 @@ export class SessionAgentPool {
   /** sessionId → modelName → in-flight request count (prevents stale close on active streams) */
   private inFlight = new Map<string, Map<string, number>>();
   private sweepTimer: ReturnType<typeof setInterval> | null = null;
-  private readonly idleTtlMs: number;
-  private readonly staleThresholdMs: number;
+  private idleTtlMs: number;
+  private staleThresholdMs: number;
 
   constructor(idleTtlMs: number = DEFAULT_SESSION_IDLE_TTL_MS, staleThresholdMs?: number) {
     this.idleTtlMs = idleTtlMs;
@@ -210,6 +210,12 @@ export class SessionAgentPool {
   /** Number of active sessions */
   get sessionCount(): number {
     return this.agents.size;
+  }
+
+  /** Update pool parameters on config hot-reload (no restart needed) */
+  updateConfig(idleTtlMs: number, staleThresholdMs: number): void {
+    this.idleTtlMs = idleTtlMs;
+    this.staleThresholdMs = staleThresholdMs;
   }
 
   /** Destroy the pool (stop sweep timer + close all) */


### PR DESCRIPTION
## Summary

- `SessionAgentPool` captured `idleTtlMs` and `staleThresholdMs` at construction time. On config hot-reload (file watch or SIGUSR1), `setConfig()` never updated these — changes to `sessionIdleTtlMs` or `staleAgentThresholdMs` were silently ignored until a full daemon restart.
- Adds `updateConfig()` method to `SessionAgentPool` and calls it from `setConfig()` with the new values computed from the reloaded config.
- Exports `DEFAULT_STALE_AGENT_THRESHOLD_MS` from `session-pool.ts` so `server.ts` can compute the min stale threshold on reload.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [x] `node dist/index.js reload` — daemon reloaded
- [ ] Edit `staleAgentThresholdMs` or `sessionIdleTtlMs` in config.yaml, verify hot-reload picks up new values (check logs for updated threshold)

Closes #164