### PR TITLE
fix: measure token speed from streaming phase only (exclude TTFB)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -99,7 +99,7 @@ function parseUsageFromData(data: Record<string, unknown>): { inputTokens: numbe
  * For non-streaming JSON responses, uses a bounded sliding-window regex scan.
  */
 function createMetricsTransform(
-  ctx: { requestId: string; model: string; actualModel?: string; tier: string; startTime: number; fallbackMode?: "sequential" | "race"; sessionId?: string; _streamState?: StreamState },
+  ctx: { requestId: string; model: string; actualModel?: string; tier: string; startTime: number; fallbackMode?: "sequential" | "race"; sessionId?: string; _streamState?: StreamState; _streamStartTime?: number },
   provider: string,
   targetProvider: string,
   metricsStore: MetricsStore,
@@ -239,8 +239,14 @@ function createMetricsTransform(
   const recordMetrics = (inp: number, out: number, cacheRead: number = 0, cacheCreation: number = 0) => {
     try {
       const latencyMs = Date.now() - ctx.startTime;
-      const latencySec = latencyMs / 1000;
-      const tps = latencySec > 0 ? out / latencySec : 0;
+      // Use streaming-only duration for TPS (exclude TTFB wait time).
+      // Only use streaming duration when it's long enough for reliable measurement
+      // (>= 200ms). Short durations (< 200ms) have huge relative error due to
+      // Date.now() resolution (~1ms), producing inflated numbers like 64K tok/s.
+      const rawStreamDurMs = ctx._streamStartTime ? Date.now() - ctx._streamStartTime : 0;
+      const durMs = rawStreamDurMs >= 200 ? rawStreamDurMs : latencyMs;
+      const tpsSec = durMs / 1000;
+      const tps = tpsSec > 0 ? out / tpsSec : 0;
 
       metricsStore.recordRequest({
         requestId: ctx.requestId,
@@ -334,6 +340,7 @@ function createMetricsTransform(
       const now = Date.now();
       if (firstChunk || now - lastStreamEmit >= STREAM_THROTTLE_MS) {
         lastStreamEmit = now;
+        if (firstChunk) ctx._streamStartTime = now; // capture streaming start (excludes TTFB)
         firstChunk = false;
         const contextWindow = getContextWindow(ctx.actualModel || ctx.model);
         setImmediate(() => {
@@ -369,6 +376,7 @@ function createMetricsTransform(
       const nowJson = Date.now();
       if (firstChunk || nowJson - lastStreamEmit >= STREAM_THROTTLE_MS) {
         lastStreamEmit = nowJson;
+        if (firstChunk) ctx._streamStartTime = nowJson; // capture streaming start (excludes TTFB)
         firstChunk = false;
         const contextWindow = getContextWindow(ctx.actualModel || ctx.model);
         setImmediate(() => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,6 +106,8 @@ export interface RequestContext {
   hasDistribution?: boolean;
   /** Tracks current StreamState for transition validation */
   _streamState?: StreamState;
+  /** Timestamp when the first streaming chunk arrived (after TTFB). Used for streaming-only TPS. */
+  _streamStartTime?: number;
   /** Retry-after value (seconds) from the last provider 429/503 response */
   _retryAfterMs?: number;
   /** Set when all providers in the chain have health < UNHEALTHY_THRESHOLD.


### PR DESCRIPTION
## Summary
- Token speed (TOK/S) previously used total wall-clock latency (including TTFB wait), producing misleadingly low averages
- Now captures `_streamStartTime` when the first streaming chunk arrives, and computes TPS using streaming-only duration
- Adds a 200ms minimum duration threshold — falls back to total latency for fast responses where timing precision is unreliable (prevents inflated numbers like 64K tok/s)

## Changes
- `src/types.ts` — added `_streamStartTime?: number` to `RequestContext`
- `src/server.ts` — capture streaming start on first chunk (SSE + JSON paths), use streaming-only duration in `recordMetrics` with 200ms floor

## Test plan
- [x] `npx tsc --noEmit` — passes
- [x] `npm run build` — succeeds
- [x] `npx vitest run` — 323/323 tests passing
- [ ] Manual: verify TOK/S shows realistic values in GUI for long streaming responses (should be higher than before)
- [ ] Manual: verify short/fast responses don't show inflated numbers