### PR TITLE
fix: respect Retry-After header for 429/503 rate limit responses

### DIFF
--- a/modelweaver.example.yaml
+++ b/modelweaver.example.yaml
@@ -49,9 +49,11 @@ providers:
   anthropic:
     baseUrl: https://api.anthropic.com
     apiKey: ${ANTHROPIC_API_KEY}
+    rateLimitBackoffMs: 1000  # delay (ms) before retrying after 429/503 when no Retry-After header
   openrouter:
     baseUrl: https://openrouter.ai/api
     apiKey: ${OPENROUTER_API_KEY}
+    rateLimitBackoffMs: 1000  # delay (ms) before retrying after 429/503 when no Retry-After header
 
 # Exact model name routing (checked FIRST, before tier patterns)
 modelRouting:

--- a/src/config.ts
+++ b/src/config.ts
@@ -139,6 +139,9 @@ const providerSchema = z.object({
   modelPools: z.record(z.string(), z.number().int().min(1).max(50)).optional(),
   connectionRetries: z.number().int().min(0).max(10).optional(),
   staleAgentThresholdMs: z.number().int().positive().optional(),
+  /** Default backoff (ms) before retrying after a 429/503 when no Retry-After header is present.
+   *  Set to 0 to disable automatic rate-limit backoff. Default: 1000 */
+  rateLimitBackoffMs: z.number().int().min(0).default(1000).optional(),
   circuitBreaker: z.object({
     failureThreshold: z.number().int().min(1).optional(),
     threshold: z.number().int().min(1).optional(),
@@ -525,6 +528,7 @@ export async function loadConfig(configPath?: string, cwd?: string): Promise<{ c
     providerConfig.poolSize = p.poolSize ?? 10;
     providerConfig._connectionRetries = p.connectionRetries;
     providerConfig._staleAgentThresholdMs = p.staleAgentThresholdMs;
+    providerConfig._rateLimitBackoffMs = p.rateLimitBackoffMs;
     // Create per-provider circuit breaker
     const cbConfig = p.circuitBreaker;
     providerConfig._circuitBreaker = new CircuitBreaker(cbConfig ? {

--- a/src/defaults/config.yaml
+++ b/src/defaults/config.yaml
@@ -24,6 +24,7 @@ providers:
       threshold: 4
       windowSeconds: 120
       cooldown: 15
+    rateLimitBackoffMs: 1000            # delay (ms) before retrying after 429/503 when no Retry-After header
 
 # ─── Routing ──────────────────────────────────────────────────────────
 # Tier-based routing: Claude Code sends model names like "claude-sonnet-4-..."

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -883,6 +883,32 @@ export async function forwardRequest(
       // HTTP framing and cause "socket closed unexpectedly" on the client.
       const errHeaders = new Headers(undiciResponse.headers as unknown as HeadersInit);
       errHeaders.delete("transfer-encoding");
+
+      // Propagate Retry-After from 429/503 responses so the fallback chain
+      // can back off instead of hammering rate-limited providers.
+      // Without this, a burst of 429s compounds into a 6+ minute stall
+      // because the chain retries immediately on every attempt.
+      if (undiciResponse.statusCode === 429 || undiciResponse.statusCode === 503) {
+        const retryAfterRaw = undiciResponse.headers["retry-after"];
+        if (retryAfterRaw) {
+          const retryAfterSec = Number(retryAfterRaw);
+          // Both seconds (numeric) and HTTP-date formats are valid;
+          // numeric is the common case for API rate limits.
+          if (!isNaN(retryAfterSec) && retryAfterSec > 0) {
+            ctx._retryAfterMs = retryAfterSec * 1000;
+          } else {
+            // Default: use provider-level backoff when Retry-After is non-numeric
+            const providerBackoff = provider._rateLimitBackoffMs ?? 1000;
+            ctx._retryAfterMs ??= providerBackoff;
+          }
+          console.warn(`[proxy] Provider "${provider.name}" returned ${undiciResponse.statusCode}, Retry-After: ${retryAfterRaw}s`);
+        } else {
+          // No Retry-After header — use provider-level configured backoff
+          const providerBackoff = provider._rateLimitBackoffMs ?? 1000;
+          ctx._retryAfterMs ??= providerBackoff;
+        }
+      }
+
       return new Response(errBody, {
         status: undiciResponse.statusCode,
         statusText: undiciResponse.statusText,
@@ -1729,13 +1755,30 @@ export async function forwardWithFallback(
           return { response, actualModel: entry.model, actualProvider: entry.provider };
         }
 
-        // Retriable error — continue to next provider
-        logger?.warn("Provider failed with retriable status, falling back", {
-          requestId: ctx.requestId,
-          provider: entry.provider,
-          status: response.status,
-          index: i,
-        });
+        // Retriable error — back off before the next attempt.
+        // If a Retry-After header was present on the 429/503, respect it so we
+        // don't hammer a still-rate-limited provider and extend the outage.
+        const backoffMs = ctx._retryAfterMs ?? 0;
+        if (backoffMs > 0) {
+          logger?.warn("Provider failed with retriable status, backing off before retry", {
+            requestId: ctx.requestId,
+            provider: entry.provider,
+            status: response.status,
+            backoffMs,
+          });
+          await new Promise(resolve => setTimeout(resolve, backoffMs));
+          // Consume the value so it's only applied once per provider attempt.
+          // The _retryAfterMs set by the 429 handler was for that specific
+          // provider; clear it so the next provider in the chain starts fresh.
+          ctx._retryAfterMs = 0;
+        } else {
+          logger?.warn("Provider failed with retriable status, falling back", {
+            requestId: ctx.requestId,
+            provider: entry.provider,
+            status: response.status,
+            index: i,
+          });
+        }
         // continue loop
       } catch {
         // Connection errors/exceptions should NOT tank health score

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,8 @@ export interface ProviderConfig {
   _connectionRetries?: number;
   /** Staleness threshold (ms) for session-scoped agents. Idle agents beyond this are proactively refreshed. Default: 30000 */
   _staleAgentThresholdMs?: number;
+  /** Configured default backoff (ms) for 429/503 rate-limited responses when no Retry-After header is present. Default: 1000 */
+  _rateLimitBackoffMs?: number;
 }
 
 export interface RoutingEntry {

--- a/tests/helpers/mock-provider.ts
+++ b/tests/helpers/mock-provider.ts
@@ -10,6 +10,7 @@ export function createMockProvider() {
   const app = new Hono();
 
   let behavior: "success" | "error-429" | "error-500" | "error-401" | "timeout" | "stall" = "success";
+  let retryAfterMs: number | undefined = undefined;
 
   app.post("/v1/messages", async (c) => {
     if (behavior === "timeout") {
@@ -48,9 +49,14 @@ export function createMockProvider() {
     }
 
     if (behavior === "error-429") {
+      const headers: Record<string, string> = {};
+      if (retryAfterMs !== undefined) {
+        headers["retry-after"] = String(Math.ceil(retryAfterMs / 1000));
+      }
       return c.json(
         { type: "error", error: { type: "rate_limit_error", message: "Rate limited" } },
-        429
+        429,
+        headers as any,
       );
     }
 
@@ -109,5 +115,6 @@ export function createMockProvider() {
         setTimeout(() => resolve(), 2000);
       }),
     setBehavior: (b: typeof behavior) => { behavior = b; },
+    setRetryAfter: (ms: number) => { retryAfterMs = ms; },
   };
 }

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -307,6 +307,62 @@ describe("forwardWithFallback race mode", () => {
     await mock1.close();
     await mock2.close();
   });
+
+  it("waits for Retry-After before falling back on 429", async () => {
+    const mock1 = createMockProvider();
+    const mock2 = createMockProvider();
+    mock1.setBehavior("error-429");
+    mock1.setRetryAfter(2000); // 2 second Retry-After (value in ms)
+
+    const provider1: ProviderConfig = {
+      name: "provider-1",
+      baseUrl: mock1.url,
+      apiKey: "test",
+      timeout: 5000,
+    };
+    const provider2: ProviderConfig = {
+      name: "provider-2",
+      baseUrl: mock2.url,
+      apiKey: "test",
+      timeout: 5000,
+    };
+
+    const providers = new Map<string, ProviderConfig>();
+    providers.set("provider-1", provider1);
+    providers.set("provider-2", provider2);
+
+    const chain: RoutingEntry[] = [
+      { provider: "provider-1" },
+      { provider: "provider-2" },
+    ];
+
+    const ctx: RequestContext = {
+      requestId: "test-429-backoff",
+      model: "test-model",
+      tier: "test",
+      providerChain: chain,
+      startTime: Date.now(),
+      rawBody: JSON.stringify({ model: "test-model", messages: [] }),
+      hasDistribution: true, // Triggers sequential fallback (not race mode)
+    };
+
+    const incoming = new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: ctx.rawBody,
+    });
+
+    const start = Date.now();
+    const result = await forwardWithFallback(providers, chain, ctx, incoming);
+    const elapsed = Date.now() - start;
+
+    expect(result.response.status).toBe(200);
+    // Should have waited ~2s for Retry-After before trying provider-2
+    expect(elapsed).toBeGreaterThanOrEqual(1800);
+
+    await mock1.close();
+    await mock2.close();
+  });
 });
 
 describe("forwardRequest TTFB timeout", () => {


### PR DESCRIPTION
## Summary

- **Parse `Retry-After` header** from 429/503 responses and propagate to the fallback chain via `ctx._retryAfterMs`
- **Apply backoff delay** before retrying the next provider in sequential fallback mode, preventing compounding retry storms
- **Add configurable `rateLimitBackoffMs`** provider option (default 1000ms) for cases without a `Retry-After` header
- **Add test coverage** for the new Retry-After backoff behavior

## Root Cause

When a provider returned 429, the proxy retried immediately without backoff. A burst of 7 consecutive 429s caused 6+ minutes of cumulative timeout delays (30s timeout × 7 attempts) before fallback recovery. The `ctx._retryAfterMs` field existed in the type but was never set or consumed.

## Test plan

- [x] All 324 existing tests pass
- [x] New test: `waits for Retry-After before falling back on 429` — verifies the 2s backoff is applied in sequential fallback mode
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [ ] Manual: verify with rate-limited provider that backoff delays appear in logs

## Config example

```yaml
providers:
  anthropic:
    baseUrl: https://api.anthropic.com
    apiKey: ${ANTHROPIC_API_KEY}
    rateLimitBackoffMs: 2000  # Custom backoff when no Retry-After header
```