### PR TITLE
feat: implement GET /v1/models endpoint

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -472,6 +472,17 @@ export function createApp(initConfig: AppConfig, logLevel: LogLevel, metricsStor
     return c.body("", 200);
   });
 
+  // OpenAI-compatible models list endpoint
+  app.get("/v1/models", (c) => {
+    const models = [...config.modelRouting.entries()].map(([modelId, entries]) => ({
+      id: modelId,
+      object: "model",
+      created: 0,
+      owned_by: entries[0]?.provider ?? "unknown",
+    }));
+    return c.json({ object: "list", data: models });
+  });
+
   app.post("/v1/messages", async (c) => {
     const requestId = randomUUID();
 


### PR DESCRIPTION
## Summary
- Adds `GET /v1/models` returning OpenAI-compatible model list from configured `modelRouting`
- Returns `{ object: "list", data: [{ id, object, created, owned_by }] }` format
- Each model's `owned_by` is set to the primary provider in its routing chain

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds
- [x] `curl http://localhost:3456/v1/models` returns 200 with all configured models
- [x] Verified response matches expected format from issue

Fixes #146