### PR TITLE
feat: detect transient errors in 400/413 response bodies

### DIFF
--- a/modelweaver.example.yaml
+++ b/modelweaver.example.yaml
@@ -54,6 +54,12 @@ providers:
     baseUrl: https://openrouter.ai/api
     apiKey: ${OPENROUTER_API_KEY}
     rateLimitBackoffMs: 1000  # delay (ms) before retrying after 429/503 when no Retry-After header
+  # Example: provider-specific transient error patterns
+  # some-provider:
+  #   retryableErrorPatterns:
+  #     - "network error"
+  #     - "code:1234"
+  #     - "please contact customer service"
 
 # Exact model name routing (checked FIRST, before tier patterns)
 modelRouting:

--- a/src/config.ts
+++ b/src/config.ts
@@ -142,6 +142,10 @@ const providerSchema = z.object({
   /** Default backoff (ms) before retrying after a 429/503 when no Retry-After header is present.
    *  Set to 0 to disable automatic rate-limit backoff. Default: 1000 */
   rateLimitBackoffMs: z.number().int().min(0).default(1000).optional(),
+  /** Custom patterns (case-insensitive substrings) that make a 400/413 response body
+   *  trigger fallback to the next provider. Useful for providers that return non-standard
+   *  error messages for transient/server-side issues. */
+  retryableErrorPatterns: z.array(z.string()).optional(),
   circuitBreaker: z.object({
     failureThreshold: z.number().int().min(1).optional(),
     threshold: z.number().int().min(1).optional(),
@@ -529,6 +533,7 @@ export async function loadConfig(configPath?: string, cwd?: string): Promise<{ c
     providerConfig._connectionRetries = p.connectionRetries;
     providerConfig._staleAgentThresholdMs = p.staleAgentThresholdMs;
     providerConfig._rateLimitBackoffMs = p.rateLimitBackoffMs;
+    providerConfig.retryableErrorPatterns = p.retryableErrorPatterns;
     // Create per-provider circuit breaker
     const cbConfig = p.circuitBreaker;
     providerConfig._circuitBreaker = new CircuitBreaker(cbConfig ? {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -254,6 +254,45 @@ export function isRetriable(status: number): boolean {
   return status === 429 || status >= 500;
 }
 
+/**
+ * Default patterns that indicate a transient/server-side error, even when
+ * the HTTP status is 400 or 413 (non-standard but common among some providers).
+ * These trigger fallback to the next provider in the chain.
+ */
+const TRANSIENT_BODY_PATTERNS = [
+  'network error',
+  'internal error',
+  'server error',
+  'overloaded',
+  'service unavailable',
+  'temporarily unavailable',
+  'upstream error',
+  'downstream error',
+  'gateway error',
+  'connect error',
+  'connection error',
+  'connection refused',
+  'timeout',
+  'rate limit',
+  'too many requests',
+  'system error',
+];
+
+/**
+ * Checks if a 4xx response body indicates a transient error that should
+ * trigger fallback to the next provider. Used for providers that return
+ * 400 with non-standard error messages for what are actually server-side
+ * or network issues (e.g. "Network error, error id: xxx").
+ */
+export function isTransientBodyError(status: number, body: string, customPatterns?: string[]): boolean {
+  if (status !== 400 && status !== 413) return false;
+  const lower = body.toLowerCase();
+  const patterns = customPatterns && customPatterns.length > 0
+    ? [...TRANSIENT_BODY_PATTERNS, ...customPatterns.map(p => p.toLowerCase())]
+    : TRANSIENT_BODY_PATTERNS;
+  return patterns.some(p => lower.includes(p));
+}
+
 const CONTEXT_WINDOW_PATTERNS = [
   'context window', 'context_limit', 'token limit',
   'prompt is too long', 'max tokens', 'input too large', 'too many tokens',
@@ -1732,27 +1771,37 @@ export async function forwardWithFallback(
         }
 
         if (!isRetriable(response.status)) {
-          // Non-retriable error — return immediately
+          // Non-retriable error — check for transient body patterns and context window errors
           if ((response.status === 400 || response.status === 413) && response.body) {
             try {
               const errBody = await response.text();
-              const handled = handleContextWindowError(response.status, errBody);
-              if (handled) return { response: handled, actualModel: entry.model, actualProvider: entry.provider };
-              return {
-                response: new Response(errBody, {
-                  status: response.status,
-                  statusText: response.statusText,
-                  // Filter transfer-encoding — body was consumed to static string
-                  headers: stripTransferEncoding(response.headers),
-                }),
-                actualModel: entry.model,
-                actualProvider: entry.provider,
-              };
+
+              // Check: is this actually a transient error disguised as a 400?
+              // Some providers return 400 with "Network error" for what is really a server-side issue.
+              if (isTransientBodyError(response.status, errBody, provider.retryableErrorPatterns)) {
+                console.warn(`[proxy] Transient body error on "${provider.name}" (HTTP ${response.status}): ${errBody.slice(0, 300)} — treating as retriable`);
+                // Fall through to retriable path below — trigger fallback to next provider
+              } else {
+                // Not transient — check for context window error
+                const handled = handleContextWindowError(response.status, errBody);
+                if (handled) return { response: handled, actualModel: entry.model, actualProvider: entry.provider };
+                return {
+                  response: new Response(errBody, {
+                    status: response.status,
+                    statusText: response.statusText,
+                    // Filter transfer-encoding — body was consumed to static string
+                    headers: stripTransferEncoding(response.headers),
+                  }),
+                  actualModel: entry.model,
+                  actualProvider: entry.provider,
+                };
+              }
             } catch {
               return { response, actualModel: entry.model, actualProvider: entry.provider };
             }
+          } else {
+            return { response, actualModel: entry.model, actualProvider: entry.provider };
           }
-          return { response, actualModel: entry.model, actualProvider: entry.provider };
         }
 
         // Retriable error — back off before the next attempt.

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,9 @@ export interface ProviderConfig {
   _staleAgentThresholdMs?: number;
   /** Configured default backoff (ms) for 429/503 rate-limited responses when no Retry-After header is present. Default: 1000 */
   _rateLimitBackoffMs?: number;
+  /** Custom body patterns (case-insensitive) that indicate transient errors on 400/413 responses.
+   *  Matched responses are treated as retriable and trigger fallback to the next provider. */
+  retryableErrorPatterns?: string[];
 }
 
 export interface RoutingEntry {

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -1,7 +1,7 @@
 // tests/proxy.test.ts
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createMockProvider } from "./helpers/mock-provider.js";
-import { forwardRequest, forwardWithFallback, isRetriable, buildOutboundUrl, buildOutboundHeaders } from "../src/proxy.js";
+import { forwardRequest, forwardWithFallback, isRetriable, isTransientBodyError, buildOutboundUrl, buildOutboundHeaders } from "../src/proxy.js";
 import type { RoutingEntry, ProviderConfig, RequestContext } from "../src/types.js";
 
 describe("isRetriable", () => {
@@ -12,6 +12,72 @@ describe("isRetriable", () => {
   it("400 is not retriable", () => expect(isRetriable(400)).toBe(false));
   it("401 is not retriable", () => expect(isRetriable(401)).toBe(false));
   it("403 is not retriable", () => expect(isRetriable(403)).toBe(false));
+});
+
+describe("isTransientBodyError", () => {
+  // Should only trigger on 400/413
+  it("returns false for 429 (already retriable via status)", () => {
+    expect(isTransientBodyError(429, '{"message":"Network error"}')).toBe(false);
+  });
+  it("returns false for 500 (already retriable via status)", () => {
+    expect(isTransientBodyError(500, '{"message":"Network error"}')).toBe(false);
+  });
+  it("returns false for 401", () => {
+    expect(isTransientBodyError(401, '{"message":"Network error"}')).toBe(false);
+  });
+
+  // Default transient patterns
+  it("detects 'network error' in body", () => {
+    const body = JSON.stringify({ error: { message: "Network error, error id: 123", code: "1234" } });
+    expect(isTransientBodyError(400, body)).toBe(true);
+  });
+  it("detects 'overloaded' in body", () => {
+    expect(isTransientBodyError(400, '{"error":{"message":"Server overloaded"}}')).toBe(true);
+  });
+  it("detects 'timeout' in body", () => {
+    expect(isTransientBodyError(413, '{"error":{"message":"Request timeout"}}')).toBe(true);
+  });
+  it("detects 'connection refused' in body", () => {
+    expect(isTransientBodyError(400, '{"error":{"message":"connection refused"}}')).toBe(true);
+  });
+  it("detects 'rate limit' in body", () => {
+    expect(isTransientBodyError(400, '{"error":{"message":"rate limit exceeded"}}')).toBe(true);
+  });
+  it("detects 'system error' in body", () => {
+    expect(isTransientBodyError(400, '{"error":{"message":"system error"}}')).toBe(true);
+  });
+
+  // Non-transient 400 errors should NOT match
+  it("returns false for context window errors", () => {
+    expect(isTransientBodyError(400, '{"error":{"message":"prompt is too long: 200000 tokens"}}')).toBe(false);
+  });
+  it("returns false for generic 400 validation errors", () => {
+    expect(isTransientBodyError(400, '{"error":{"message":"invalid request: missing field"}}')).toBe(false);
+  });
+  it("returns false for empty body", () => {
+    expect(isTransientBodyError(400, "")).toBe(false);
+  });
+
+  // Custom patterns
+  it("matches custom provider-specific patterns", () => {
+    const body = JSON.stringify({ error: { message: "API Error: something broke" } });
+    expect(isTransientBodyError(400, body, ["API Error"])).toBe(true);
+  });
+  it("custom patterns work alongside defaults", () => {
+    // "network error" is a default, "please contact" is custom
+    const body = '{"error":{"message":"please contact customer service"}}';
+    expect(isTransientBodyError(400, body, ["please contact"])).toBe(true);
+  });
+  it("empty custom patterns array falls back to defaults only", () => {
+    expect(isTransientBodyError(400, '{"error":{"message":"network error"}}', [])).toBe(true);
+    expect(isTransientBodyError(400, '{"error":{"message":"please contact"}}', [])).toBe(false);
+  });
+
+  // Case insensitive
+  it("is case-insensitive", () => {
+    expect(isTransientBodyError(400, '{"error":{"message":"NETWORK ERROR"}}')).toBe(true);
+    expect(isTransientBodyError(400, '{"error":{"message":"Network Error"}}')).toBe(true);
+  });
 });
 
 describe("buildOutboundUrl", () => {


### PR DESCRIPTION
## Summary

- Some providers (e.g. GLM) return HTTP 400 with "Network error" for transient server-side issues — previously treated as permanent client errors with no fallback
- Adds body-aware retryability: 16 default transient patterns + per-provider configurable `retryableErrorPatterns` in YAML
- When a 400/413 body matches a transient pattern, the fallback chain kicks in and tries the next provider

## Changes

| File | Change |
|------|--------|
| `src/proxy.ts` | `isTransientBodyError()` with 16 default patterns + fallback chain integration |
| `src/types.ts` | `retryableErrorPatterns?: string[]` on `ProviderConfig` |
| `src/config.ts` | Zod schema + config loader mapping |
| `modelweaver.example.yaml` | Commented example for new config field |
| `tests/proxy.test.ts` | 16 tests (340 total passing) |

## Example config

```yaml
providers:
  glm:
    retryableErrorPatterns:
      - "network error"
      - "API Error"
      - "please contact customer service"
```

## Test plan

- [x] 16 new unit tests for `isTransientBodyError` (defaults, custom patterns, case-insensitivity, edge cases)
- [x] Full suite passes (340/340)
- [x] TypeScript compiles cleanly
- [x] Daemon reloaded and running in production