### PR TITLE
fix: skip hedging on single-provider chains

### DIFF
--- a/src/hedging.ts
+++ b/src/hedging.ts
@@ -122,10 +122,15 @@ export const inFlightCounter = new InFlightCounter();
  * Clamped by available concurrency slots: maxConcurrent - inFlight.
  * Calibration note: production data shows glm/minimax have CV 1.5-4.0 (extreme tail variance),
  * so hedging is warranted. CV threshold of 0.5 prevents over-hedging on stable runs.
+ *
+ * IMPORTANT: Hedging is skipped (returns 1) when the provider chain has only one entry.
+ * Multi-copy hedging to a single provider multiplies load on a rate-limited endpoint —
+ * it can never improve outcome and makes 429 bursts worse.
  */
 export function computeHedgingCount(
   provider: ProviderConfig,
   config?: { cvThreshold?: number; maxHedge?: number },
+  chainLength?: number,
 ): number {
   const cv = latencyTracker.getCV(provider.name);
   const inFlight = inFlightCounter.get(provider.name);
@@ -134,6 +139,10 @@ export function computeHedgingCount(
 
   const cvThreshold = config?.cvThreshold ?? 0.5;
   const maxHedge = config?.maxHedge ?? 4;
+
+  // Skip hedging for single-provider chains — multi-copy to the same provider
+  // can never improve outcome and amplifies rate-limit bursts (e.g. 429 × 3).
+  if (chainLength !== undefined && chainLength <= 1) return 1;
 
   if (cv < cvThreshold) return 1;
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1493,8 +1493,9 @@ async function hedgedForwardRequest(
   hedging?: HedgingConfig,
   probeId?: number,
   sessionPool?: SessionAgentPool,
+  chainLength?: number,
 ): Promise<Response> {
-  const count = ctx.hasDistribution ? 1 : computeHedgingCount(provider, hedging);
+  const count = ctx.hasDistribution ? 1 : computeHedgingCount(provider, hedging, chainLength);
 
   if (count <= 1) {
     // No hedging — single request (with automatic retry on timeout)
@@ -1685,7 +1686,7 @@ export async function forwardWithFallback(
     onAttempt?.(entry.provider, 0);
 
     const singleStart = Date.now();
-    const response = await hedgedForwardRequest(provider, entry, ctx, incomingRequest, undefined, 0, logger, hedging, singleProbeId, sessionPool);
+    const response = await hedgedForwardRequest(provider, entry, ctx, incomingRequest, undefined, 0, logger, hedging, singleProbeId, sessionPool, chain.length);
     const success = response.status >= 200 && response.status < 300;
     const isConnErr = response.status === 502 && await isConnectionErrorBody(response);
     if (!isConnErr) {
@@ -1736,7 +1737,7 @@ export async function forwardWithFallback(
       try {
         const response = await hedgedForwardRequest(
           provider, entry, ctx, incomingRequest, undefined, i, logger, hedging,
-          cbProbeId, sessionPool,
+          cbProbeId, sessionPool, chain.length,
         );
 
         const attemptLatency = Date.now() - attemptStart;
@@ -1902,6 +1903,7 @@ export async function forwardWithFallback(
         hedging,
         cbProbeId,
         sessionPool,
+        chain.length,
       );
       const attemptLatency = Date.now() - attemptStart;
       const success = response.status >= 200 && response.status < 300;


### PR DESCRIPTION
## Summary
- **Problem**: When a provider chain has only one entry, adaptive hedging still fires multiple copies (up to `maxHedge`) to the same provider. This is counterproductive — it can never improve latency (all copies hit the same endpoint) and amplifies rate-limit bursts.
- **Evidence**: `claude-sonnet-4-6` → tier2 → `glm` (single provider) generated **27 429 errors in ~20 minutes** because hedging (cv: 1.49) sent 3 copies per request to the same rate-limited GLM endpoint.
- **Fix**: `computeHedgingCount()` now returns `1` when `chainLength <= 1`, skipping hedging for single-provider chains entirely.

## Changes
- `src/hedging.ts` — `computeHedgingCount()`: added `chainLength` param; returns 1 immediately for single-provider chains
- `src/proxy.ts` — `hedgedForwardRequest()`: added `chainLength` param, forwarded to `computeHedgingCount`
- All 3 call sites (single-provider, sequential fallback, racing) now pass `chain.length`

## Test plan
- [ ] Verify `claude-sonnet-4-6` requests through tier2 no longer generate hedge log entries
- [ ] Verify multi-provider chains (e.g. `MiniMax-M2.7` with 5 providers) still hedge normally
- [ ] Monitor `~/.modelweaver/modelweaver.log` for reduction in 429 errors from GLM