### PR TITLE
fix: align context trim to safe message boundary

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -737,9 +737,26 @@ export async function forwardRequest(
       const parsed = JSON.parse(body);
       if (Array.isArray(parsed.messages) && parsed.messages.length > provider.maxContextMessages) {
         const original = parsed.messages.length;
-        parsed.messages = parsed.messages.slice(-provider.maxContextMessages);
+        let trimmed = parsed.messages.slice(-provider.maxContextMessages);
+        // Align to safe boundary: find the first `user` message that is NOT a tool_result.
+        // This avoids orphaned tool_result entries (which need a preceding tool_use).
+        let safeStart = 0;
+        for (let i = 0; i < trimmed.length; i++) {
+          const msg = trimmed[i];
+          if (msg.role === "user" && !(Array.isArray(msg.content) && msg.content.some((b: any) => b?.type === "tool_result"))) {
+            safeStart = i;
+            break;
+          }
+          // Also accept a plain assistant text message as a safe start
+          if (msg.role === "assistant" && typeof msg.content === "string") {
+            safeStart = i;
+            break;
+          }
+        }
+        if (safeStart > 0) trimmed = trimmed.slice(safeStart);
+        parsed.messages = trimmed;
         body = JSON.stringify(parsed);
-        console.warn(`[context-trim] Trimmed messages from ${original} to ${provider.maxContextMessages} for provider ${provider.name}`);
+        console.warn(`[context-trim] Trimmed messages from ${original} to ${trimmed.length} (limit: ${provider.maxContextMessages}) for provider ${provider.name}`);
       }
     } catch {
       // If body can't be parsed, skip trimming


### PR DESCRIPTION
## Summary
Naive `slice(-N)` could split `tool_use`/`tool_result` pairs, causing orphaned tool results without preceding tool calls. This confused upstream models — agents would echo instead of executing tasks.

## Fix
After slicing, walk forward from the start of the trimmed array to find the first safe boundary:
- A `user` message that is NOT a `tool_result`
- Or a plain `assistant` text message

This ensures the upstream model always receives a coherent conversation starting from a fresh turn.

## Before
```
[329] user: tool_result ← orphaned, no tool_use before it
[330] assistant: tool_use(write_file, ...)  ← confused model
```

## After
```
[332] user: "now add tests"  ← clean start
[333] assistant: tool_use(read_file, ...)   ← coherent conversation
```