### PR TITLE
fix: inject continuation hint when trimming to prevent agent stalls

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -780,6 +780,18 @@ export async function forwardRequest(
           trimmed = [firstInstruction, ...trimmed];
         }
 
+        // Inject a continuation hint after the instruction so the model knows
+        // earlier context was trimmed and it should keep working, not stop prematurely.
+        const trimmedCount = original - trimmed.length;
+        if (trimmedCount > 0 && trimmed.length > 1) {
+          const hint = {
+            role: "user",
+            content: `[System: ${trimmedCount} earlier messages were trimmed to fit context window. Continue working on the original task — do not stop until it is fully complete.]`,
+          };
+          // Insert after the instruction (index 0) and before the rest
+          trimmed = [trimmed[0], hint, ...trimmed.slice(1)];
+        }
+
         parsed.messages = trimmed;
         body = JSON.stringify(parsed);
         const turnsKept = turnStarts.filter(s => s >= bestStart).length;


### PR DESCRIPTION
## Summary
When `maxContextMessages` trims context, the upstream model sees recent tool results without full history and may conclude the task is done — returning `end_turn` prematurely. The agent then stalls.

## Fix
Inject a continuation hint as a `user` message right after the preserved instruction:
```
[System: 150 earlier messages were trimmed to fit context window. Continue working on the original task — do not stop until it is fully complete.]
```

This tells the model:
1. Context was intentionally trimmed (not a bug)
2. The original task is still in progress
3. It should keep executing, not summarize and stop