### PR TITLE
feat: per-type tool result compression and malformed response protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,68 @@
 
 All notable changes to ModelWeaver.
 
+## [v0.3.83] — 2026-04-22
+
+### Fixes
+
+- **Empty response detection** — detect upstream `end_turn` responses with 0 output tokens and no content, then trigger fallback retry with the next provider in the chain (#248)
+- **Context trim duplicate instruction** — prevent injecting duplicate system instructions when the original task instruction is already present after trimming (#247)
+- **Accurate needsInstruction check** — fix `needsInstruction` to correctly detect when synthetic SSE events lack the `input_tokens` field (#247)
+
+## [v0.3.82] — 2026-04-21
+
+### Fixes
+
+- **Hint boundary alignment** — ensure continuation hints are injected at the correct message boundary, not mid-conversation (#247)
+- **Fallback on trim failure** — if context trimming produces an invalid message array, fall back to the original untrimmed messages (#247)
+
+## [v0.3.81] — 2026-04-20
+
+### Fixes
+
+- **5 context trimming bugfixes** — fix off-by-one message boundary, preserve `tool_result` pairs, handle empty message arrays, prevent trimming during streaming, and validate message role sequences (#246)
+
+## [v0.3.80] — 2026-04-19
+
+### Fixes
+
+- **Skip context trim during active tool chains** — avoid trimming conversation history while a multi-step tool chain is in progress, preventing broken `tool_use`→`tool_result` sequences (#245)
+
+## [v0.3.79] — 2026-04-18
+
+### Fixes
+
+- **Inject continuation hint on trim** — when context is trimmed, inject a synthetic assistant message hinting the model to continue, preventing agent stalls from lost conversation state (#244)
+
+## [v0.3.78] — 2026-04-17
+
+### Features
+
+- **Turn-aware context trimming** — trim context at conversation turn boundaries instead of arbitrary message counts, preserving complete `user`/`assistant` exchanges and `tool_use`/`tool_result` pairs (#243)
+
+## [v0.3.77] — 2026-04-16
+
+### Fixes
+
+- **Preserve original task instruction** — when trimming context, keep the original task/system instruction at the top of the message array instead of losing it (#242)
+
+## [v0.3.76] — 2026-04-15
+
+### Fixes
+
+- **Safe message boundary alignment** — ensure context trimming cuts at valid message boundaries (always after an `assistant` turn), preventing malformed request arrays (#241)
+
+## [v0.3.75] — 2026-04-14
+
+### Features
+
+- **Per-provider context message trimming** �� new `maxContextMessages` provider option limits outgoing conversation history to the most recent N messages, reducing token waste on long sessions (#239)
+
+### Fixes
+
+- **Stream state race** — fix truncated responses when using OpenAI-compatible upstream providers caused by eager Transform streams
+- **Versioned URL construction** — OpenAI adapter handles versioned base URLs (e.g., `/v4`) without double-prefixing
+
 ## [v0.3.69] — 2026-04-07
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ No config file editing. No provider SDK installs. The wizard tests your API key 
 - **Empty response detection** — detects when upstream providers return empty `end_turn` (0 output tokens, no content) and automatically retries with the next provider in the fallback chain (#248)
 - **Context trimming fixes** — duplicate instruction prevention, accurate `needsInstruction` check, missing `input_tokens` in synthetic SSE events (#247)
 
+## What's New — v0.3.78
+
+- **Turn-aware context trimming** — context is now trimmed at conversation turn boundaries instead of arbitrary message counts, preserving complete `user`/`assistant` exchanges and `tool_use`/`tool_result` pairs (#243)
+- **Continuation hints** — when context is trimmed, a synthetic assistant message is injected to hint the model to continue, preventing agent stalls (#244)
+- **Tool chain protection** — context trimming is skipped during active tool chains to avoid breaking multi-step tool sequences (#245)
+
 ## What's New — v0.3.75
 
 - **Per-provider context message trimming** — set `maxContextMessages` to limit outgoing conversation history, reducing token waste on long sessions (#239)

--- a/specs.md
+++ b/specs.md
@@ -1,0 +1,269 @@
+The clean way is to put a translation shim between the OpenAI-style backend and the Anthropic-style frontend that Claude Code expects.
+
+At a high level:
+
+Claude Code side wants Anthropic Messages semantics: assistant output arrives as content blocks like text and tool_use, and tool returns go back in as tool_result content blocks. Anthropic’s streaming docs show assistant output as content_block_start / content_block_delta, with tool use emitted as a tool_use block containing id, name, and input.
+OpenAI-style backends usually return Chat Completions semantics: assistant text in choices[0].message.content, and tool calls in choices[0].message.tool_calls, where each call has an id, type: "function", function.name, and function.arguments as a JSON string.
+
+So the adapter’s job is simple:
+
+1) OpenAI request in, Anthropic request out
+
+When Claude Code sends a request in Anthropic format, convert it before calling the OpenAI-style backend.
+
+Anthropic-style input
+{
+  "model": "claude-opus-4-7",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Fix this function."
+    }
+  ],
+  "tools": [
+    {
+      "name": "read_file",
+      "description": "Read a file",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "path": { "type": "string" }
+        },
+        "required": ["path"]
+      }
+    }
+  ]
+}
+Convert to OpenAI-style request
+{
+  "model": "glm-5.1",
+  "messages": [
+    {
+      "role": "system",
+      "content": "You are Claude Code-compatible. Use tools when needed."
+    },
+    {
+      "role": "user",
+      "content": "Fix this function."
+    }
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "read_file",
+        "description": "Read a file",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "path": { "type": "string" }
+          },
+          "required": ["path"]
+        }
+      }
+    }
+  ]
+}
+
+That mapping is valid because Anthropic tools use name, description, and input_schema, while OpenAI tool definitions use type: "function" plus function.parameters.
+
+2) OpenAI response in, Anthropic response out
+
+This is the part you asked for.
+
+If OpenAI returns normal text
+
+OpenAI-style:
+
+{
+  "choices": [
+    {
+      "message": {
+        "role": "assistant",
+        "content": "Here is the fix..."
+      },
+      "finish_reason": "stop"
+    }
+  ]
+}
+
+Return to Claude Code as Anthropic-style:
+
+{
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "Here is the fix..."
+    }
+  ],
+  "stop_reason": "end_turn"
+}
+
+That matches Anthropic’s content-block model, where text is a type: "text" block.
+
+If OpenAI returns a tool call
+
+OpenAI-style:
+
+{
+  "choices": [
+    {
+      "message": {
+        "role": "assistant",
+        "content": null,
+        "tool_calls": [
+          {
+            "id": "call_123",
+            "type": "function",
+            "function": {
+              "name": "read_file",
+              "arguments": "{\"path\":\"main.py\"}"
+            }
+          }
+        ]
+      },
+      "finish_reason": "tool_calls"
+    }
+  ]
+}
+
+Return to Claude Code as Anthropic-style:
+
+{
+  "role": "assistant",
+  "content": [
+    {
+      "type": "tool_use",
+      "id": "call_123",
+      "name": "read_file",
+      "input": {
+        "path": "main.py"
+      }
+    }
+  ],
+  "stop_reason": "tool_use"
+}
+
+That mapping is the core one. OpenAI exposes tool calls under tool_calls, and Anthropic expresses the same intent as a tool_use content block.
+
+3) Tool result mapping back into the next turn
+
+After Claude Code executes the tool, it will want to continue the conversation with a tool result.
+
+Anthropic expects tool outputs as tool_result content blocks in the next user turn; Anthropic’s docs explicitly mention tool_use blocks in requests and responses and tool_result blocks in requests.
+
+Anthropic-style tool result
+{
+  "role": "user",
+  "content": [
+    {
+      "type": "tool_result",
+      "tool_use_id": "call_123",
+      "content": "def foo():\n    pass\n"
+    }
+  ]
+}
+
+Convert that to OpenAI-style tool message:
+
+{
+  "role": "tool",
+  "tool_call_id": "call_123",
+  "content": "def foo():\n    pass\n"
+}
+
+OpenAI Chat Completions supports role: "tool" messages, and tool messages may carry string content or text content parts.
+
+4) The exact field map
+
+Use this map and you’ll stay sane:
+
+OpenAI-style	Anthropic-style
+message.content: "text"	content: [{type:"text", text:"text"}]
+message.tool_calls[i].id	content[j].id on tool_use
+message.tool_calls[i].function.name	content[j].name on tool_use
+JSON.parse(message.tool_calls[i].function.arguments)	content[j].input on tool_use
+finish_reason: "tool_calls"	stop_reason: "tool_use"
+role: "tool", tool_call_id, content	role: "user", content:[{type:"tool_result", tool_use_id, content}]
+
+That is the harmonization layer.
+
+5) Streaming mapping
+
+If you want Claude Code to behave nicely, stream in Anthropic event shape, not raw OpenAI chunks.
+
+Anthropic streaming uses events like:
+
+message_start
+content_block_start
+content_block_delta
+content_block_stop
+message_delta
+message_stop
+
+So if your OpenAI backend streams deltas, buffer them and re-emit Anthropic-shaped events.
+
+For plain text:
+
+first text token → emit content_block_start with {type:"text", text:""}
+each delta token → emit content_block_delta with {type:"text_delta", text:"..."}
+at end → emit content_block_stop
+then message_delta with stop_reason:"end_turn"
+then message_stop
+
+For tool calls:
+
+when OpenAI starts a function call, emit Anthropic content_block_start with type:"tool_use"
+stream arguments as input_json_delta
+end with message_delta.stop_reason = "tool_use"
+
+That is the closest behavioral match for Claude Code.
+
+6) What usually breaks
+
+Been there. These are the usual footguns.
+
+First, don’t forward OpenAI content arrays blindly. OpenAI supports richer content parts, but many “OpenAI-compatible” vendors only partially implement them. Anthropic also uses its own content-block types. Normalize everything internally to:
+
+text
+tool_use
+tool_result
+maybe image/document later
+
+Second, parse tool arguments safely. OpenAI documents that tool arguments are returned as a JSON string and may not always be valid JSON. Validate before turning them into Anthropic input.
+
+Third, don’t try to preserve hidden reasoning verbatim. Anthropic streaming has special thinking modes, and OpenAI has its own reasoning products, but these are not wire-compatible. For a Claude Code shim, translate only the visible text/tool behavior unless you are deliberately emulating thinking blocks.
+
+7) The simplest adapter algorithm
+1. Receive Anthropic-style request from Claude Code
+2. Convert messages/tools to OpenAI-style
+3. Call OpenAI-compatible backend
+4. If response has assistant text:
+   -> emit Anthropic assistant text block
+5. If response has tool_calls:
+   -> emit Anthropic tool_use block(s)
+6. Receive tool results from Claude Code
+7. Convert tool_result to OpenAI role=tool message
+8. Continue loop
+8) My blunt recommendation
+
+Use an internal canonical model instead of translating directly back and forth everywhere.
+
+Something like:
+
+{
+  "role": "assistant",
+  "segments": [
+    { "kind": "text", "text": "..." },
+    { "kind": "tool_call", "id": "call_123", "name": "read_file", "input": { "path": "main.py" } }
+  ],
+  "stop_reason": "tool_use"
+}
+
+Then write:
+
+Anthropic encoder/decoder
+OpenAI encoder/decoder
+
+That avoids turning your proxy into spaghetti.

--- a/src/config.ts
+++ b/src/config.ts
@@ -137,6 +137,7 @@ const providerSchema = z.object({
   modelLimits: modelLimitsSchema,
   concurrentLimit: z.number().int().min(1).optional(),
   maxContextMessages: z.number().int().positive().optional(),
+  toolResultLimit: z.number().int().positive().optional(),
   poolSize: z.number().int().min(1).max(100).optional(),
   modelPools: z.record(z.string(), z.number().int().min(1).max(50)).optional(),
   connectionRetries: z.number().int().min(0).max(10).optional(),
@@ -521,6 +522,8 @@ export async function loadConfig(configPath?: string, cwd?: string): Promise<{ c
       modelLimits: p.modelLimits ? { maxOutputTokens: p.modelLimits.maxOutputTokens } : undefined,
       concurrentLimit: p.concurrentLimit,
       modelPools: p.modelPools !== undefined ? { ...p.modelPools } : undefined,
+      maxContextMessages: p.maxContextMessages,
+      toolResultLimit: p.toolResultLimit,
     };
     try {
       const parsedUrl = new URL(p.baseUrl);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -523,6 +523,184 @@ function cleanOrphanedToolMessages(body: Record<string, unknown>): void {
 }
 
 /**
+ * Compress tool_result content blocks using per-type strategies.
+ *
+ * 4 buckets based on tool name:
+ *   source     — Read: wider head (60/40), preserves line-numbered output
+ *   logs       — Bash: head 20 lines + error lines + tail 50 lines
+ *   structured — Grep/Glob/search: keep match lines, drop noise
+ *   default    — everything else: head+tail with guardrails
+ *
+ * Builds a tool_use_id -> tool_name index from assistant messages for bucket classification.
+ * Mutates body.messages in-place (same pattern as cleanOrphanedToolMessages).
+ */
+
+type CompressionBucket = "source" | "logs" | "structured" | "default";
+
+const TOOL_BUCKET: Record<string, CompressionBucket> = {
+  // Source material — exact lines matter
+  Read: "source",
+  read: "source",
+  // Execution output — preserve errors + tail
+  Bash: "logs",
+  bash: "logs",
+  "shell-exec": "logs",
+  // Structured lookup — keep matches, drop noise
+  Grep: "structured",
+  Glob: "structured",
+  grep: "structured",
+  glob: "structured",
+  WebSearch: "structured",
+  WebFetch: "structured",
+  search: "structured",
+  list: "structured",
+};
+
+const LOGS_HEAD_LINES = 20;
+const LOGS_TAIL_LINES = 50;
+const ERROR_LINE_RE = /\b(Error|error|FAIL|fatal|WARN|warn|Exception|TypeError|ReferenceError|SyntaxError|exit code|EXIT|FAILED|SEVERE)\b/;
+
+function compressSource(text: string, limit: number, toolName: string): string {
+  const headChars = Math.floor(limit * 0.6);
+  const tailChars = limit - headChars;
+  const head = text.slice(0, headChars);
+  const tail = text.slice(text.length - tailChars);
+  const truncated = text.length - limit;
+  return `${head}\n\n... [${truncated.toLocaleString()} chars compressed from ${toolName} — preserving top/bottom sections] ...\n\n${tail}`;
+}
+
+function compressLogs(text: string, limit: number, toolName: string): string {
+  const lines = text.split("\n");
+  if (lines.length <= LOGS_HEAD_LINES + LOGS_TAIL_LINES + 10) {
+    // Short enough — use default head+tail char compression
+    return compressDefault(text, limit, toolName);
+  }
+
+  const head = lines.slice(0, LOGS_HEAD_LINES);
+  const tail = lines.slice(-LOGS_TAIL_LINES);
+  const middle = lines.slice(LOGS_HEAD_LINES, -LOGS_TAIL_LINES);
+
+  // Extract error/warning lines from middle
+  const errorLines = middle.filter(l => ERROR_LINE_RE.test(l));
+
+  const skipped = middle.length - errorLines.length;
+  const parts: string[] = [...head];
+  if (errorLines.length > 0) {
+    parts.push(`\n... [${skipped} lines skipped, errors/warnings preserved] ...`);
+    parts.push(...errorLines);
+  } else {
+    parts.push(`\n... [${skipped} lines skipped] ...`);
+  }
+  parts.push(...tail);
+
+  const result = parts.join("\n");
+  if (result.length <= limit) return result;
+
+  // Still too long — fall back to char-level compression
+  return compressDefault(result, limit, toolName);
+}
+
+function compressStructured(text: string, limit: number, toolName: string): string {
+  const lines = text.split("\n");
+
+  // Keep substantive lines — drop blanks, separators, repeated headers
+  const kept: string[] = [];
+  let dropped = 0;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed === "" || /^[─═─━─\-=]{3,}$/.test(trimmed)) {
+      dropped++;
+      continue;
+    }
+    kept.push(line);
+  }
+
+  const result = kept.join("\n");
+  if (result.length <= limit) {
+    return dropped > 0 ? `${result}\n\n[${dropped} blank/separator lines removed from ${toolName} result]` : result;
+  }
+
+  // Still over limit — keep first half and last half of match lines
+  const half = Math.floor(kept.length / 2);
+  const headLines = kept.slice(0, half);
+  const tailLines = kept.slice(-half);
+  const midDropped = kept.length - headLines.length - tailLines.length;
+  const compressed = `${headLines.join("\n")}\n\n... [${midDropped} results compressed from ${toolName}] ...\n\n${tailLines.join("\n")}`;
+
+  if (compressed.length <= limit) return compressed;
+
+  return compressDefault(compressed, limit, toolName);
+}
+
+function compressDefault(text: string, limit: number, toolName: string): string {
+  const half = Math.floor(limit / 2);
+  const head = text.slice(0, half);
+  const tail = text.slice(text.length - half);
+  const truncated = text.length - limit;
+  return `${head}\n\n... [${truncated.toLocaleString()} chars compressed from ${toolName}] ...\n\n${tail}`;
+}
+
+const COMPRESSORS: Record<CompressionBucket, (text: string, limit: number, toolName: string) => string> = {
+  source: compressSource,
+  logs: compressLogs,
+  structured: compressStructured,
+  default: compressDefault,
+};
+
+function compressToolResults(body: Record<string, unknown>, limit: number): void {
+  const messages = body.messages;
+  if (!Array.isArray(messages)) return;
+
+  // Fast exit: scan for tool_result blocks
+  let hasResults = false;
+  for (const msg of messages) {
+    if (msg.role !== "user" || !Array.isArray(msg.content)) continue;
+    for (const block of msg.content) {
+      if (block.type === "tool_result") { hasResults = true; break; }
+    }
+    if (hasResults) break;
+  }
+  if (!hasResults) return;
+
+  // Build tool_use_id -> tool_name index from assistant messages
+  const toolNames = new Map<string, string>();
+  for (const msg of messages) {
+    if (msg.role !== "assistant" || !Array.isArray(msg.content)) continue;
+    for (const block of msg.content) {
+      if (block.type === "tool_use" && block.id && block.name) {
+        toolNames.set(String(block.id), String(block.name));
+      }
+    }
+  }
+
+  // Compress each tool_result block exceeding the limit
+  for (const msg of messages) {
+    if (msg.role !== "user" || !Array.isArray(msg.content)) continue;
+    for (const block of msg.content) {
+      if (block.type !== "tool_result") continue;
+
+      let text: string;
+      if (typeof block.content === "string") {
+        text = block.content;
+      } else if (Array.isArray(block.content)) {
+        text = block.content
+          .filter((b: any) => b.type === "text")
+          .map((b: any) => b.text)
+          .join("\n");
+      } else {
+        continue;
+      }
+
+      if (text.length <= limit) continue;
+
+      const toolName = toolNames.get(String(block.tool_use_id)) ?? "unknown";
+      const bucket = TOOL_BUCKET[toolName] ?? "default";
+      block.content = COMPRESSORS[bucket](text, limit, toolName);
+    }
+  }
+}
+
+/**
  * Apply targeted string replacements to rawBody to preserve prompt caching.
  * On the primary attempt (chainIndex === 0), we avoid full JSON.stringify which
  * breaks Anthropic's cache breakpoints (position-sensitive, whitespace/order-sensitive).
@@ -535,14 +713,14 @@ function applyTargetedReplacements(
   parsed: Record<string, unknown>,
   needsOrphanClean: boolean,
   needsThinkingStrip = false,
+  needsCompression = false,
 ): string {
-  // If orphan cleaning or thinking stripping is needed, fall back to full JSON
-  // (orphan clean requires structural changes; thinking requires nested-brace handling)
-  if (needsOrphanClean || needsThinkingStrip) {
-    // shallow clone: cleanOrphanedToolMessages reassigns body.messages
+  // If orphan cleaning, thinking stripping, or compression is needed, fall back to full JSON
+  if (needsOrphanClean || needsThinkingStrip || needsCompression) {
     const mutable = shallowCloneForMutation(parsed);
     if (entry.model) mutable.model = entry.model;
     if (needsOrphanClean) cleanOrphanedToolMessages(mutable);
+    if (provider.toolResultLimit) compressToolResults(mutable, provider.toolResultLimit);
     if (provider.modelLimits) {
       const { maxOutputTokens } = provider.modelLimits;
       const requested = typeof mutable.max_tokens === "number" ? mutable.max_tokens : maxOutputTokens;
@@ -701,14 +879,43 @@ export async function forwardRequest(
       const needsThinkingStrip = !!(provider._serverConfig?.disableThinking && parsed.thinking !== undefined);
       if (needsThinkingStrip) needsModification = true;
 
+      // Check 5: Tool result compression needed?
+      // Only trigger full mutation when tool_result blocks actually exist AND are oversized.
+      // Avoids forcing JSON.stringify on every request (breaks prompt cache).
+      let needsCompression = false;
+      if (provider.toolResultLimit && Array.isArray(parsed.messages)) {
+        for (const msg of parsed.messages) {
+          if (msg.role !== "user" || !Array.isArray(msg.content)) continue;
+          for (const block of msg.content) {
+            if (block.type === "tool_result") {
+              // Found a tool_result — check if it's actually oversized
+              let textLen = 0;
+              if (typeof block.content === "string") textLen = block.content.length;
+              else if (Array.isArray(block.content)) {
+                for (const b of block.content) {
+                  if (b.type === "text" && typeof b.text === "string") textLen += b.text.length;
+                }
+              }
+              if (textLen > provider.toolResultLimit) {
+                needsCompression = true;
+                break;
+              }
+            }
+          }
+          if (needsCompression) break;
+        }
+      }
+      if (needsCompression) needsModification = true;
+
       if (needsModification) {
-        // On primary attempt (chainIndex === 0) without orphan cleaning, use targeted
-        // string replacements to preserve prompt caching. Anthropic's cache breakpoints
-        // are position-sensitive -- JSON.stringify changes whitespace/order, breaking hits.
-        if (chainIndex === 0 && !needsOrphanClean) {
+        // On primary attempt (chainIndex === 0) without orphan cleaning or compression,
+        // use targeted string replacements to preserve prompt caching.
+        // Anthropic's cache breakpoints are position-sensitive -- JSON.stringify changes
+        // whitespace/order, breaking hits.
+        if (chainIndex === 0 && !needsOrphanClean && !needsCompression) {
           body = applyTargetedReplacements(ctx.rawBody, entry, provider, parsed, false, needsThinkingStrip);
         } else {
-          // Fallback attempts: full JSON parse/mutate/stringify (caching already broken)
+          // Full JSON parse/mutate/stringify (caching already broken or compression needed)
           // shallow clone: cleanOrphanedToolMessages reassigns body.messages
           const mutable = shallowCloneForMutation(parsed);
 
@@ -724,6 +931,10 @@ export async function forwardRequest(
 
           if (needsOrphanClean) {
             cleanOrphanedToolMessages(mutable);
+          }
+
+          if (provider.toolResultLimit) {
+            compressToolResults(mutable, provider.toolResultLimit);
           }
 
           if (provider.modelLimits) {
@@ -1379,6 +1590,19 @@ export async function forwardRequest(
 
     passThrough.on("end", () => {
       if (stallTimerRef) { clearTimeout(stallTimerRef); stallTimerRef = undefined; }
+      // Stream ended without any SSE data — resolve as empty so the inspection
+      // path triggers fallback instead of forwarding a blank response.
+      const bytes = (passThrough as any)._bytesForwarded ?? 0;
+      if (inspectResolve && bytes === 0) {
+        console.warn(`[empty-response] Provider "${provider.name}" returned zero-byte response (HTTP 200) — triggering fallback`);
+        inspectResolve("empty");
+        inspectResolve = undefined;
+      } else if (inspectResolve && !sawMessageStart && bytes > 0) {
+        // Got bytes but no valid SSE — malformed response
+        console.warn(`[empty-response] Provider "${provider.name}" returned ${bytes}b with no message_start (malformed SSE) — triggering fallback`);
+        inspectResolve("empty");
+        inspectResolve = undefined;
+      }
     });
 
     passThrough.on("error", () => {
@@ -1410,9 +1634,25 @@ export async function forwardRequest(
         const safeClose = () => {
           if (controllerClosed) return;
           controllerClosed = true;
-          // If the upstream ended without sending message_stop, the stream is incomplete.
-          // Inject the missing Anthropic SSE events to prevent Y8.content crash.
-          if (!sawMessageStop && ((passThrough as any)._bytesForwarded ?? 0) > 0) {
+          // Zero-byte or no message_start: upstream returned an empty/malformed response.
+          // Inject a complete synthetic SSE message so Claude Code gets a parseable
+          // response instead of crashing on empty content.
+          const bytes = (passThrough as any)._bytesForwarded ?? 0;
+          if (bytes === 0 || !sawMessageStart) {
+            console.warn(`[safeClose] Empty/malformed stream: bytes=${bytes} msgStart=${sawMessageStart} — injecting error message`);
+            const msgId = `msg_proxy_empty_${Date.now()}`;
+            const errorChunks = [
+              `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { id: msgId, type: "message", role: "assistant", model: "proxy", content: [], stop_reason: null, stop_sequence: null, usage: { input_tokens: 0, output_tokens: 0 } } })}\n\n`,
+              `event: content_block_start\ndata: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } })}\n\n`,
+              `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "[Proxy error: upstream returned empty/malformed response. Retrying may help.]" } })}\n\n`,
+              `event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 0 })}\n\n`,
+              `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 20 } })}\n\n`,
+              `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`,
+            ];
+            for (const chunk of errorChunks) {
+              try { controller.enqueue(new TextEncoder().encode(chunk)); } catch { /* already closed */ }
+            }
+          } else if (!sawMessageStop) {
             console.warn(`[safeClose] Injecting closing events: bytes=${(passThrough as any)._bytesForwarded} start=${sawMessageStart} blockStart=${sawContentBlockStart} blockStop=${sawContentBlockStop} msgStop=${sawMessageStop}`);
             // Upstream ended without sending message_stop — stream is incomplete.
             // Inject only the missing events to prevent Y8.content crash.

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,8 @@ export interface ProviderConfig {
   concurrentLimit?: number;
   /** Max conversation messages to forward upstream. Keeps only the most recent N messages. */
   maxContextMessages?: number;
+  /** Max characters per tool_result content block. Head+tail truncation if exceeded. */
+  toolResultLimit?: number;
 
   /** Runtime-only cached fields — not serialized to config */
   _cachedHost?: string;

--- a/test-transformer.mjs
+++ b/test-transformer.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+import { Readable } from 'node:stream';
+
+// Use tsx to run source directly
+const mod = await import('tsx/esm/register');
+const { createOpenAIChatToAnthropicStream } = await import('./src/adapters/openai-utils.ts');
+
+// Simulate a real OpenAI SSE response
+const mockOpenAIResponse = `data: {"id":"test123","created":1234567890,"object":"chat.completion.chunk","model":"glm-5-turbo","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"},"finish_reason":null}]}
+
+data: {"id":"test123","created":1234567890,"object":"chat.completion.chunk","model":"glm-5-turbo","choices":[{"index":0,"delta":{"content":" world"},"finish_reason":null}]}
+
+data: {"id":"test123","created":1234567890,"object":"chat.completion.chunk","model":"glm-5-turbo","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+
+data: [DONE]
+
+`;
+
+console.error('=== Output (Anthropic SSE) ===');
+
+const input = Readable.from([mockOpenAIResponse]);
+const transformer = createOpenAIChatToAnthropicStream();
+
+let outputChunks = [];
+transformer.on('data', (chunk) => {
+  outputChunks.push(chunk.toString());
+  process.stdout.write(chunk);
+});
+
+transformer.on('end', () => {
+  console.error('\n=== Transform complete ===');
+  console.error(`Total output chunks: ${outputChunks.length}`);
+  console.error(`Total bytes: ${outputChunks.join('').length}`);
+});


### PR DESCRIPTION
## Summary

- Add `toolResultLimit` per-provider config for compressing oversized `tool_result` blocks using a 4-bucket strategy (source/logs/structured/default)
- Fix latent `maxContextMessages` propagation bug in config builder (was in Zod schema but never copied to runtime `ProviderConfig`)
- Only trigger compression when oversized tool_results actually exist — preserves prompt cache on simple text-only requests
- Detect empty/malformed upstream responses (zero-byte or no `message_start`) and trigger fallback instead of forwarding garbage to Claude Code
- Inject synthetic SSE error message as last-chance safety net in `safeClose()`

## Context sharpening — tool result compression

Instead of blunt head+tail truncation, tool results are classified into 4 buckets by tool name:

| Bucket | Tools | Strategy |
|--------|-------|----------|
| source | Read | 60/40 head-tail (code is top-heavy) |
| logs | Bash | First 20 + error lines + last 50 lines |
| structured | Grep/Glob/search | Strip blanks/separators, keep matches |
| default | everything else | 50/50 head-tail |

## Malformed response protection

GLM occasionally returns HTTP 200 with an empty body. The previous detection only caught `end_turn` with 0 output tokens. New detection:
- `passThrough.on("end")` resolves "empty" for zero-byte and no-`message_start` responses
- `safeClose()` injects complete synthetic SSE error message when stream is empty/malformed

## Test plan

- [ ] Add `toolResultLimit: 4000` to a provider in config
- [ ] Send requests with large `Read` tool results — verify source bucket compression
- [ ] Send requests with large `Bash` output — verify error lines preserved
- [ ] Send simple text-only requests — verify prompt cache intact (no unnecessary JSON.stringify)
- [ ] Verify fallback triggers on empty/malformed upstream responses
