### PR TITLE
fix: session pool provider isolation, request count, adaptive hedging

### DIFF
--- a/src/hedging.ts
+++ b/src/hedging.ts
@@ -39,6 +39,15 @@ export class LatencyTracker {
     }
   }
 
+  /** P50 (median) latency in ms. Returns 0 if insufficient data. */
+  getP50(provider: string): number {
+    const window = this.samples.get(provider);
+    if (!window || window.length < 5) return 0;
+    const sorted = window.map(s => s.ttfbMs).sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    return sorted.length % 2 !== 0 ? sorted[mid] : Math.round((sorted[mid - 1] + sorted[mid]) / 2);
+  }
+
   /** Coefficient of variation (stddev / mean). Returns 0 if insufficient data. */
   getCV(provider: string): number {
     const window = this.samples.get(provider);
@@ -149,6 +158,18 @@ export function computeHedgingCount(
   // Linear scale: cv=0.5 → 2 copies, cv=1.0 → 3, cv=1.5+ → 4
   const adaptive = Math.min(maxHedge, Math.floor((cv - cvThreshold) * 2 + 2));
   return Math.max(1, Math.min(adaptive, available));
+}
+
+/**
+ * Compute adaptive speculative delay based on provider's p50 latency.
+ * Falls back to static `speculativeDelay` when insufficient samples (<5).
+ */
+export function getAdaptiveDelay(providerName: string, config: { speculativeDelay: number; speculativeDelayFactor?: number } | undefined, fallbackMs: number): number {
+  const staticDelay = config?.speculativeDelay ?? fallbackMs;
+  const p50 = latencyTracker.getP50(providerName);
+  if (p50 <= 0) return staticDelay;
+  const factor = config?.speculativeDelayFactor ?? 0.5;
+  return Math.min(Math.round(p50 * factor), staticDelay);
 }
 
 // --- Hedge win/loss tracking ---

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -145,17 +145,9 @@ export class MetricsStore {
         }
       }
 
-      // Decrement session counter for evicted entry
-      if (evicted.sessionId) {
-        const sEntry = this._sessionMap.get(evicted.sessionId);
-        if (sEntry) {
-          sEntry.count--;
-          if (sEntry.count <= 0) {
-            this._sessionMap.delete(evicted.sessionId);
-            if (this._sessionMapMin.current === evicted.sessionId) this._sessionMapMin.current = null;
-          }
-        }
-      }
+      // NOTE: session counter is NOT decremented on eviction — it tracks lifetime
+      // request count, not ring-buffer-window count. Cleanup happens via SESSION_IDLE_TTL_MS
+      // in getSummary() which removes entries idle beyond the threshold.
     }
 
     // Increment counters for new entry
@@ -224,7 +216,8 @@ export class MetricsStore {
       } else {
         this._sessionMap.set(metrics.sessionId, { count: 1, lastSeen: metrics.timestamp });
       }
-      this.pruneMap(this._sessionMap, (e) => e.count, this._sessionMapMin);
+      // Prune by lastSeen (oldest idle first) since count is now a lifetime counter
+      this.pruneMap(this._sessionMap, (e) => e.lastSeen, this._sessionMapMin);
     }
 
     // Enforce size caps on maps

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -61,7 +61,7 @@ import type { SessionAgentPool } from "./session-pool.js";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { latencyTracker, inFlightCounter, computeHedgingCount, recordHedgeWin, recordHedgeLosses } from './hedging.js';
+import { latencyTracker, inFlightCounter, computeHedgingCount, recordHedgeWin, recordHedgeLosses, getAdaptiveDelay } from './hedging.js';
 import { warmupProvider } from './pool.js';
 import { resolveAdaptiveTTFB } from './adaptive-timeout.js';
 import { recordHealthEvent } from './health-score.js';
@@ -1225,8 +1225,8 @@ export async function forwardRequest(
   let streamCreated = false;
 
   try {
-    // Use session-scoped agent when available (per-session, per-model connection isolation),
-    const dispatcher = sessionPool?.get(ctx.sessionId, poolModel) ?? getOrCreateAgent(provider, poolModel);
+    // Use session-scoped agent when available (per-session, per-model+provider connection isolation),
+    const dispatcher = sessionPool?.get(ctx.sessionId, poolModel, provider.name) ?? getOrCreateAgent(provider, poolModel);
     const undiciResponse = await Promise.race([
       undiciRequest(url, {
         method: "POST",
@@ -1727,7 +1727,7 @@ export async function forwardRequest(
           // Decrement in-flight count so the stale refresh knows this stream is done.
           // This is safe to call multiple times since release() is idempotent.
           if (sessionPool && ctx.sessionId) {
-            sessionPool.release(ctx.sessionId, ctx.actualModel ?? ctx.model);
+            sessionPool.release(ctx.sessionId, ctx.actualModel ?? ctx.model, provider.name);
           }
           // Transition stream state to "complete" and broadcast for GUI.
           // Only fire for normal stream completion (state was "streaming"),
@@ -1829,7 +1829,7 @@ export async function forwardRequest(
         // Guard against double-release: safeClose() (from passThrough "close" event)
         // may have already released if cancel() fires after the stream ended.
         if (sessionPool && ctx.sessionId && !controllerClosed) {
-          sessionPool.release(ctx.sessionId, ctx.actualModel ?? ctx.model);
+          sessionPool.release(ctx.sessionId, ctx.actualModel ?? ctx.model, provider.name);
         }
       },
     });
@@ -1952,7 +1952,7 @@ export async function forwardRequest(
     // the release — finally does NOT release there (would cause count=0 while stream
     // is still active → sweep() could close the agent mid-stream).
     if (sessionPool && ctx.sessionId && !streamCreated) {
-      sessionPool.release(ctx.sessionId, poolModel);
+      sessionPool.release(ctx.sessionId, poolModel, provider.name);
     }
   }
 }
@@ -2038,7 +2038,7 @@ async function forwardWithRetry(
       // to this provider. The session pool eviction gives the retry a fresh
       // session-scoped connection while leaving the shared pool intact.
       if (sessionPool && ctx.sessionId) {
-        sessionPool.evict(ctx.sessionId, ctx.actualModel ?? ctx.model);
+        sessionPool.evict(ctx.sessionId, ctx.actualModel ?? ctx.model, provider.name);
       }
 
       const delay = CONNECTION_RETRY_BASE_MS * Math.pow(2, attempt);
@@ -2292,7 +2292,7 @@ export async function forwardWithFallback(
           console.warn(`[proxy] Single-provider chain detected transient body error on "${provider.name}" (HTTP ${response.status}): ${errBody.slice(0, 300)} — retrying with fresh pool`);
           // Evict session agent to force a new connection on retry
           if (sessionPool && ctx.sessionId) {
-            sessionPool.evict(ctx.sessionId, ctx.actualModel ?? ctx.model);
+            sessionPool.evict(ctx.sessionId, ctx.actualModel ?? ctx.model, provider.name);
             ctx.sessionId = undefined;
           }
           // Retry once with fresh pool
@@ -2539,13 +2539,15 @@ export async function forwardWithFallback(
 
   // Build staggered race promises:
   //   Provider 0 starts immediately
-  //   Provider 1+ start after SPECULATIVE_DELAY (if race not already won)
+  //   Provider 1+ start after adaptive delay (based on provider p50, capped at speculativeDelay)
   const races: Promise<{ response: Response; index: number }>[] = [];
 
   for (let i = 0; i < chain.length; i++) {
     if (i === 0) {
       races.push(attemptProvider(0));
     } else {
+      const entry = chain[i];
+      const delay = getAdaptiveDelay(entry.provider, hedging, DEFAULT_SPECULATIVE_DELAY);
       races.push(
         new Promise<{ response: Response; index: number }>((resolve) => {
           setTimeout(() => {
@@ -2558,7 +2560,7 @@ export async function forwardWithFallback(
               return;
             }
             attemptProvider(i).then(resolve);
-          }, hedging?.speculativeDelay ?? DEFAULT_SPECULATIVE_DELAY);
+          }, delay);
         }),
       );
     }

--- a/src/session-pool.ts
+++ b/src/session-pool.ts
@@ -28,19 +28,22 @@ const SWEEP_INTERVAL_MS = 60_000; // sweep every 60s
 export const DEFAULT_STALE_AGENT_THRESHOLD_MS = 30_000;
 
 /**
- * Manages per-session per-model undici Agents.
- * Each session gets its own dedicated HTTP/2 connection per model name,
- * enabling TCP isolation between concurrent model streams (e.g. main agent
- * on sonnet + subagents on haiku never contend for the same connection).
+ * Manages per-session per-model-per-provider undici Agents.
+ * Each session gets its own dedicated HTTP/2 connection per (model, provider) pair,
+ * enabling TCP isolation between concurrent model streams and ensuring different
+ * providers serving the same model get separate connections.
+ *
+ * The internal key is `${providerName}/${modelName}` so that e.g. glm-5.1 served
+ * by both "glm" and "glm_openai" providers gets two independent agents/connections.
  *
  * Falls back to the shared provider agent when no session ID is present.
  */
 export class SessionAgentPool {
-  /** sessionId → modelName → Agent */
+  /** sessionId → compositeKey (providerName/modelName) → Agent */
   private agents = new Map<string, Map<string, Agent>>();
-  /** sessionId → modelName → last activity timestamp */
+  /** sessionId → compositeKey → last activity timestamp */
   private lastActivity = new Map<string, Map<string, number>>();
-  /** sessionId → modelName → in-flight request count (prevents stale close on active streams) */
+  /** sessionId → compositeKey → in-flight request count (prevents stale close on active streams) */
   private inFlight = new Map<string, Map<string, number>>();
   /** sessionId → human-readable name (from x-session-name header or Claude Code JSONL slug) */
   private sessionNames = new Map<string, string>();
@@ -59,10 +62,10 @@ export class SessionAgentPool {
   }
 
   /**
-   * Get or create a session-scoped agent for the given model.
+   * Get or create a session-scoped agent for the given model+provider.
    * Returns null if no sessionId (caller should use shared pool).
    */
-  get(sessionId: string | undefined, modelName: string): Dispatcher | null {
+  get(sessionId: string | undefined, modelName: string, providerName: string): Dispatcher | null {
     if (!sessionId) return null;
 
     // Lazily resolve Claude Code session slug on first encounter
@@ -70,13 +73,14 @@ export class SessionAgentPool {
       this.resolveSlug(sessionId);
     }
 
+    const key = `${providerName}/${modelName}`;
     let modelMap = this.agents.get(sessionId);
     if (!modelMap) {
       modelMap = new Map();
       this.agents.set(sessionId, modelMap);
     }
 
-    let agent = modelMap.get(modelName);
+    let agent = modelMap.get(key);
 
     // Connection pre-check: if the agent has been idle beyond the staleness
     // threshold AND has no in-flight requests, its HTTP/2 connection may be
@@ -84,13 +88,13 @@ export class SessionAgentPool {
     // IMPORTANT: never close an agent with in-flight streams — that kills the
     // HTTP/2 connection mid-stream, causing "socket closed unexpectedly" errors.
     if (agent) {
-      const lastActive = this.lastActivity.get(sessionId)?.get(modelName);
-      const active = this.inFlight.get(sessionId)?.get(modelName) ?? 0;
+      const lastActive = this.lastActivity.get(sessionId)?.get(key);
+      const active = this.inFlight.get(sessionId)?.get(key) ?? 0;
       if (lastActive && Date.now() - lastActive > this.staleThresholdMs && active === 0) {
         const idleS = Math.round((Date.now() - lastActive) / 1000);
-        console.log(`[session-pool] refreshing stale agent ${sessionId.slice(0, 8)}…/${modelName} (idle ${idleS}s > ${this.staleThresholdMs / 1000}s threshold, no in-flight streams)`);
+        console.log(`[session-pool] refreshing stale agent ${sessionId.slice(0, 8)}…/${key} (idle ${idleS}s > ${this.staleThresholdMs / 1000}s threshold, no in-flight streams)`);
         agent.close().catch(() => {});
-        modelMap.delete(modelName);
+        modelMap.delete(key);
         agent = undefined;
       }
     }
@@ -103,7 +107,7 @@ export class SessionAgentPool {
         allowH2: true,
         pingInterval: 10_000, // HTTP/2 PING every 10s — detect dead connections in background
       });
-      modelMap.set(modelName, agent);
+      modelMap.set(key, agent);
     }
 
     // Track activity and in-flight count
@@ -112,14 +116,14 @@ export class SessionAgentPool {
       activityMap = new Map();
       this.lastActivity.set(sessionId, activityMap);
     }
-    activityMap.set(modelName, Date.now());
+    activityMap.set(key, Date.now());
 
     let flightMap = this.inFlight.get(sessionId);
     if (!flightMap) {
       flightMap = new Map();
       this.inFlight.set(sessionId, flightMap);
     }
-    flightMap.set(modelName, (flightMap.get(modelName) ?? 0) + 1);
+    flightMap.set(key, (flightMap.get(key) ?? 0) + 1);
 
     return agent;
   }
@@ -196,16 +200,17 @@ export class SessionAgentPool {
     this.slugResolving.set(sessionId, promise);
   }
 
-  /** Decrement in-flight count for a session+model (call when request completes) */
-  release(sessionId: string, modelName: string): void {
+  /** Decrement in-flight count for a session+model+provider (call when request completes) */
+  release(sessionId: string, modelName: string, providerName: string): void {
+    const key = `${providerName}/${modelName}`;
     const flightMap = this.inFlight.get(sessionId);
     if (flightMap) {
-      const count = (flightMap.get(modelName) ?? 1) - 1;
+      const count = (flightMap.get(key) ?? 1) - 1;
       if (count <= 0) {
-        flightMap.delete(modelName);
+        flightMap.delete(key);
         if (flightMap.size === 0) this.inFlight.delete(sessionId);
       } else {
-        flightMap.set(modelName, count);
+        flightMap.set(key, count);
       }
     }
   }
@@ -215,21 +220,21 @@ export class SessionAgentPool {
     const now = Date.now();
     const deadSessions = new Set<string>();
 
-    for (const [sessionId, providerMap] of this.lastActivity) {
+    for (const [sessionId, activityMap] of this.lastActivity) {
       let allIdle = true;
-      for (const [modelName, lastActive] of providerMap) {
+      for (const [key, lastActive] of activityMap) {
         if (now - lastActive > this.idleTtlMs) {
           // Close the idle agent
-          const agent = this.agents.get(sessionId)?.get(modelName);
+          const agent = this.agents.get(sessionId)?.get(key);
           if (agent) agent.close().catch(() => {});
-          this.agents.get(sessionId)?.delete(modelName);
-          providerMap.delete(modelName);
-          this.inFlight.get(sessionId)?.delete(modelName);
+          this.agents.get(sessionId)?.delete(key);
+          activityMap.delete(key);
+          this.inFlight.get(sessionId)?.delete(key);
         } else {
           allIdle = false;
         }
       }
-      if (allIdle || providerMap.size === 0) {
+      if (allIdle || activityMap.size === 0) {
         deadSessions.add(sessionId);
       }
     }
@@ -245,15 +250,16 @@ export class SessionAgentPool {
     }
   }
 
-  /** Close and remove a specific session+model agent (e.g., on connection error) */
-  evict(sessionId: string, modelName: string): void {
-    const agent = this.agents.get(sessionId)?.get(modelName);
+  /** Close and remove a specific session+model+provider agent (e.g., on connection error) */
+  evict(sessionId: string, modelName: string, providerName: string): void {
+    const key = `${providerName}/${modelName}`;
+    const agent = this.agents.get(sessionId)?.get(key);
     if (agent) {
       agent.close().catch(() => {});
-      this.agents.get(sessionId)?.delete(modelName);
-      this.lastActivity.get(sessionId)?.delete(modelName);
+      this.agents.get(sessionId)?.delete(key);
+      this.lastActivity.get(sessionId)?.delete(key);
     }
-    this.inFlight.get(sessionId)?.delete(modelName);
+    this.inFlight.get(sessionId)?.delete(key);
     // Clean up empty session entries
     if (this.agents.get(sessionId)?.size === 0) {
       this.agents.delete(sessionId);
@@ -286,8 +292,8 @@ export class SessionAgentPool {
   getStats(): SessionStats[] {
     const now = Date.now();
     const result: SessionStats[] = [];
-    for (const [sessionId, providerMap] of this.lastActivity) {
-      const entries = [...providerMap.entries()];
+    for (const [sessionId, activityMap] of this.lastActivity) {
+      const entries = [...activityMap.entries()];
       if (entries.length === 0) continue; // skip stale entries (sweep may have emptied the map)
       result.push({
         id: sessionId,
@@ -295,7 +301,8 @@ export class SessionAgentPool {
         modelCount: entries.length,
         lastActivity: new Date(Math.max(...entries.map(([, ts]) => ts))).toISOString(),
         idleMs: now - Math.max(...entries.map(([, ts]) => ts)),
-        models: entries.map(([name]) => name),
+        // Composite key is "providerName/modelName" — extract model part for display
+        models: entries.map(([key]) => key.includes('/') ? key.split('/').slice(1).join('/') : key),
       });
     }
     return result;

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,8 +65,10 @@ export interface SmartRoutingConfig {
 }
 
 export interface HedgingConfig {
-  /** Delay (ms) before starting backup providers in staggered race */
+  /** Delay (ms) before starting backup providers in staggered race — also serves as max cap for adaptive delay */
   speculativeDelay: number;
+  /** Multiplier on provider p50 latency to compute adaptive delay. Default: 0.5 (hedge at half p50) */
+  speculativeDelayFactor?: number;
   /** Coefficient of variation threshold — hedging activates when CV >= this */
   cvThreshold: number;
   /** Maximum number of hedged copies per request */

--- a/tests/session-pool.test.ts
+++ b/tests/session-pool.test.ts
@@ -15,7 +15,7 @@ describe("SessionAgentPool", () => {
   describe("idle TTL", () => {
     it("uses default 10-minute TTL", () => {
       pool = new SessionAgentPool();
-      pool.get("sess-1", "provider-a");
+      pool.get("sess-1", "claude-sonnet-4-6", "anthropic");
       // Advance past one sweep (60s) — session still well within 10min TTL
       vi.advanceTimersByTime(60_000);
       expect(pool.sessionCount).toBe(1);
@@ -29,7 +29,7 @@ describe("SessionAgentPool", () => {
 
     it("accepts custom TTL via constructor", () => {
       pool = new SessionAgentPool(30_000);
-      pool.get("sess-1", "provider-a");
+      pool.get("sess-1", "claude-sonnet-4-6", "anthropic");
       // Advance past first sweep (60s) — idle 60s > 30s TTL, session swept
       vi.advanceTimersByTime(60_000);
       expect(pool.sessionCount).toBe(0);
@@ -44,53 +44,50 @@ describe("SessionAgentPool", () => {
 
     it("returns per-session stats with models", () => {
       pool = new SessionAgentPool();
-      const now = Date.now();
-      vi.setSystemTime(now);
-      pool.get("sess-1", "anthropic");
-      pool.get("sess-1", "openai");
-      pool.get("sess-2", "anthropic");
-
+      pool.get("sess-1", "claude-sonnet-4-6", "anthropic");
+      pool.get("sess-1", "glm-5.1", "glm");
       const stats = pool.getStats();
-      expect(stats).toHaveLength(2);
-      const s1 = stats.find(s => s.id === "sess-1")!;
-      expect(s1.modelCount).toBe(2);
-      expect(s1.models).toContain("anthropic");
-      expect(s1.models).toContain("openai");
-      expect(s1.idleMs).toBe(0);
-
-      const s2 = stats.find(s => s.id === "sess-2")!;
-      expect(s2.modelCount).toBe(1);
-      expect(s2.models).toEqual(["anthropic"]);
+      expect(stats).toHaveLength(1);
+      expect(stats[0].modelCount).toBe(2);
+      expect(stats[0].models).toEqual(["claude-sonnet-4-6", "glm-5.1"]);
     });
 
-    it("reports correct idleMs", () => {
+    it("tracks idle time", () => {
       pool = new SessionAgentPool();
-      const now = Date.now();
-      vi.setSystemTime(now);
-      pool.get("sess-1", "anthropic");
+      pool.get("sess-1", "claude-sonnet-4-6", "anthropic");
       vi.advanceTimersByTime(60_000);
       const stats = pool.getStats();
       expect(stats[0].idleMs).toBe(60_000);
     });
+
+    it("separates connections for same model across providers", () => {
+      pool = new SessionAgentPool();
+      pool.get("sess-1", "glm-5.1", "glm");
+      pool.get("sess-1", "glm-5.1", "glm_openai");
+      const stats = pool.getStats();
+      expect(stats[0].modelCount).toBe(2);
+      // Both entries show the same model name (provider prefix stripped for display)
+      expect(stats[0].models).toEqual(["glm-5.1", "glm-5.1"]);
+    });
   });
 
   describe("evict", () => {
-    it("removes specific session+model agent", () => {
+    it("removes specific session+model+provider agent", () => {
       pool = new SessionAgentPool();
-      pool.get("sess-1", "anthropic");
-      pool.get("sess-1", "openai");
+      pool.get("sess-1", "glm-5.1", "glm");
+      pool.get("sess-1", "glm-5.1", "glm_openai");
       expect(pool.sessionCount).toBe(1);
 
-      pool.evict("sess-1", "anthropic");
+      pool.evict("sess-1", "glm-5.1", "glm");
       expect(pool.sessionCount).toBe(1);
       const stats = pool.getStats();
-      expect(stats[0].models).toEqual(["openai"]);
+      expect(stats[0].models).toEqual(["glm-5.1"]);
     });
 
     it("removes session when last provider is evicted", () => {
       pool = new SessionAgentPool();
-      pool.get("sess-1", "anthropic");
-      pool.evict("sess-1", "anthropic");
+      pool.get("sess-1", "glm-5.1", "glm");
+      pool.evict("sess-1", "glm-5.1", "glm");
       expect(pool.sessionCount).toBe(0);
     });
   });
@@ -98,7 +95,7 @@ describe("SessionAgentPool", () => {
   describe("get() without sessionId", () => {
     it("returns null when no sessionId", () => {
       pool = new SessionAgentPool();
-      expect(pool.get(undefined, "anthropic")).toBeNull();
+      expect(pool.get(undefined, "glm-5.1", "glm")).toBeNull();
       expect(pool.sessionCount).toBe(0);
     });
   });


### PR DESCRIPTION
## Summary

- **Fix session request count** — `requestCount` was decremented when ring buffer entries were evicted, showing a window count instead of lifetime count. Now monotonically increasing, with idle-time-based pruning.
- **Fix session pool provider isolation** — Pool keyed by `(sessionId, modelName)` caused different providers (`glm` / `glm_openai`) serving the same model (`glm-5.1`) to share one HTTP/2 connection. Now keys by `(sessionId, providerName/modelName)` so each provider gets its own connection. GUI correctly shows "2 conns" instead of "1 conn".
- **Add adaptive hedging delay** — Replaces fixed 1000ms speculative delay with `min(p50 × factor, speculativeDelay)`. Faster hedge activation for slow providers, fewer wasted copies for fast ones. Falls back to static delay with <5 samples.

Closes #270

## Test plan

- [ ] Verify GUI session section shows correct connection count per provider
- [ ] Verify session request count only increases, never decreases
- [ ] Verify hedging delay adapts per-provider by checking `/api/hedging/stats` before/after requests
- [ ] Confirm existing fallback chain behavior unchanged when no hedging config