### PR TITLE
feat: prewarm config flag + warmup on hot-reload

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -441,6 +441,8 @@ async function main() {
             pruneHealthScores([...newConfig.providers.keys()]);
             pruneWarmupStates([...newConfig.providers.keys()]);
             clearHedgeStats();
+            // Pre-warm connections for new/changed providers
+            warmupAll(newConfig.providers).catch(() => {});
           },
         })
       : { cleanup: () => {} };
@@ -454,6 +456,7 @@ async function main() {
         latencyTracker.prune([...newConfig.providers.keys()]);
         pruneProviderLatencySamples([...newConfig.providers.keys()]);
         clearHedgeStats();
+        warmupAll(newConfig.providers).catch(() => {});
         logger.info("Config reloaded (SIGUSR1)", { path: configPath });
       } catch (err) {
         if (err instanceof ConfigValidationError) {
@@ -613,6 +616,8 @@ async function main() {
           latencyTracker.prune([...newConfig.providers.keys()]);
           pruneProviderLatencySamples([...newConfig.providers.keys()]);
           clearHedgeStats();
+          // Pre-warm connections for new/changed providers
+          warmupAll(newConfig.providers).catch(() => {});
         },
       })
     : { cleanup: () => {} };

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -161,7 +161,7 @@ export async function warmupProvider(provider: ProviderConfig): Promise<boolean>
  */
 export async function warmupAll(providers: Map<string, ProviderConfig>): Promise<Map<string, boolean>> {
   const results = new Map<string, boolean>();
-  const entries = [...providers.entries()];
+  const entries = [...providers.entries()].filter(([, p]) => p.prewarm !== false);
 
   if (entries.length === 0) return results;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,8 @@ export interface ProviderConfig {
   /** Custom body patterns (case-insensitive) that indicate transient errors on 400/413 responses.
    *  Matched responses are treated as retriable and trigger fallback to the next provider. */
   retryableErrorPatterns?: string[];
+  /** Pre-warm connection on startup/reload (HEAD request to establish TLS). Default: true */
+  prewarm?: boolean;
 }
 
 export interface RoutingEntry {


### PR DESCRIPTION
## Summary

- Add `prewarm` boolean flag to `ProviderConfig` (default: `true`) — set `prewarm: false` to skip connection warmup for specific providers
- `warmupAll()` now filters out providers with `prewarm: false`
- Add `warmupAll()` to all 3 config hot-reload paths so new/changed providers get pre-warmed after config edit — previously only ran at initial startup

Closes #268

## Test plan

- [ ] Verify warmup runs at startup (check `/api/pool` for warmup status)
- [ ] Edit config to add a new provider, verify warmup triggers on hot-reload
- [ ] Set `prewarm: false` on a provider, verify it's skipped during warmup
- [ ] All 386 tests pass