### PR TITLE
fix: cap hedge count to concurrentLimit + fix safeClose false positive

### DIFF
--- a/src/hedging.ts
+++ b/src/hedging.ts
@@ -147,7 +147,7 @@ export function computeHedgingCount(
   const available = Math.max(1, maxConcurrent - inFlight);
 
   const cvThreshold = config?.cvThreshold ?? 0.5;
-  const maxHedge = config?.maxHedge ?? 4;
+  const maxHedge = Math.min(config?.maxHedge ?? 4, maxConcurrent);
 
   // Skip hedging for single-provider chains — multi-copy to the same provider
   // can never improve outcome and amplifies rate-limit bursts (e.g. 429 × 3).

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1697,12 +1697,18 @@ export async function forwardRequest(
           const bytes = (passThrough as any)._bytesForwarded ?? 0;
           const isStallHandled = !!(passThrough as any)._intentionalClose;
           if ((bytes === 0 || !sawMessageStart || (sawMessageStop && !sawRealContent)) && !isStallHandled) {
-            // Zero-byte, no message_start, or upstream completed without real content.
+            // Zero-byte or upstream completed without real content.
             // Inject a complete synthetic SSE message so Claude Code gets a parseable
             // response instead of crashing on empty content.
             // Skip when _intentionalClose — stall/hedge handlers already wrote graceful
             // termination events; injecting more would corrupt the stream.
-            console.warn(`[safeClose] Empty/malformed stream: bytes=${bytes} msgStart=${sawMessageStart} realContent=${sawRealContent} stallHandled=${isStallHandled} — injecting error message`);
+            // Skip when sawRealContent — real content proves the stream was valid;
+            // !sawMessageStart with sawRealContent is a detection gap, not a malformed stream.
+            if (sawRealContent) {
+              console.warn(`[safeClose] Stream had real content but msgStart=${sawMessageStart} — likely detection gap, skipping error injection (requestId=${ctx.requestId}, bytes=${bytes})`);
+              // Fall through to normal closing events below
+            } else {
+            console.warn(`[safeClose] Empty/malformed stream: bytes=${bytes} msgStart=${sawMessageStart} realContent=${sawRealContent} stallHandled=${isStallHandled} requestId=${ctx.requestId} — injecting error message`);
             const msgId = `msg_proxy_empty_${Date.now()}`;
             const errorChunks = [
               `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { id: msgId, type: "message", role: "assistant", model: "proxy", content: [], stop_reason: null, stop_sequence: null, usage: { input_tokens: 0, output_tokens: 0 } } })}\n\n`,
@@ -1714,6 +1720,7 @@ export async function forwardRequest(
             ];
             for (const chunk of errorChunks) {
               try { controller.enqueue(new TextEncoder().encode(chunk)); } catch { /* already closed */ }
+            }
             }
           } else if (!sawMessageStop) {
             console.warn(`[safeClose] Injecting closing events: bytes=${(passThrough as any)._bytesForwarded} start=${sawMessageStart} blockStart=${sawContentBlockStart} blockStop=${sawContentBlockStop} msgStop=${sawMessageStop}`);


### PR DESCRIPTION
## Summary
- **Hedging cap**: `maxHedge` is now capped to the provider's `concurrentLimit`. With GLM's `maxHedge: 4` and `concurrentLimit: 2`, 4 copies were sent per request — 2-3 got rate-limited (error 1302), causing 22/41 = 54% error rate. Now capped to 2, within GLM's limit.
- **safeClose false positive**: Skip error injection when `sawRealContent=true`. The `!sawMessageStart` check was firing on valid streams (2887 bytes, real content parsed) because the 500-byte rolling buffer missed the event. This injected `[Proxy error: upstream returned empty/malformed response]` into valid 200 responses, causing Claude Code to show "API returned an empty or malformed response (HTTP 200)".
- Added `requestId` to `safeClose` logs for future debugging.

## Test plan
- [x] All 386 tests pass
- [ ] Monitor GLM error rate — should drop from ~54% to near 0%
- [ ] Verify no more "empty or malformed response" errors in Claude Code