### PR TITLE
fix: add speculativeDelayFactor and prewarm to Zod config schema

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -160,6 +160,8 @@ const providerSchema = z.object({
     windowSeconds: cb.windowSeconds,
     cooldownSeconds: cb.cooldownSeconds ?? cb.cooldown,
   })).optional(),
+  /** Whether to pre-warm the connection pool on startup. Default: true */
+  prewarm: z.boolean().default(true).optional(),
 });
 
 const routingEntrySchema = z.object({
@@ -171,6 +173,8 @@ const routingEntrySchema = z.object({
 const hedgingSchema = z.object({
   /** Delay (ms) before starting backup providers in staggered race */
   speculativeDelay: z.number().int().positive().default(500),
+  /** Multiplier on provider p50 latency to compute adaptive delay. Default: 0.5 (hedge at half p50) */
+  speculativeDelayFactor: z.number().min(0).max(5).default(0.5).optional(),
   /** Coefficient of variation threshold — hedging activates when CV >= this */
   cvThreshold: z.number().min(0).max(10).default(0.5),
   /** Maximum number of hedged copies per request */
@@ -319,6 +323,7 @@ export function peekConfig(
   const hedgingRaw = parsed?.hedging as Record<string, unknown> | undefined;
   const hedging = hedgingRaw ? {
     speculativeDelay: Number(hedgingRaw.speculativeDelay ?? 500),
+    speculativeDelayFactor: hedgingRaw.speculativeDelayFactor != null ? Number(hedgingRaw.speculativeDelayFactor) : undefined,
     cvThreshold: Number(hedgingRaw.cvThreshold ?? 0.5),
     maxHedge: Number(hedgingRaw.maxHedge ?? 4),
   } : undefined;
@@ -524,6 +529,7 @@ export async function loadConfig(configPath?: string, cwd?: string): Promise<{ c
       modelPools: p.modelPools !== undefined ? { ...p.modelPools } : undefined,
       maxContextMessages: p.maxContextMessages,
       toolResultLimit: p.toolResultLimit,
+      prewarm: p.prewarm,
     };
     try {
       const parsedUrl = new URL(p.baseUrl);
@@ -590,6 +596,7 @@ export async function loadConfig(configPath?: string, cwd?: string): Promise<{ c
     modelRouting,
     hedging: validated.hedging ? {
       speculativeDelay: validated.hedging.speculativeDelay,
+      speculativeDelayFactor: validated.hedging.speculativeDelayFactor,
       cvThreshold: validated.hedging.cvThreshold,
       maxHedge: validated.hedging.maxHedge,
     } : undefined,


### PR DESCRIPTION
## Summary
- Add `speculativeDelayFactor` to `hedgingSchema` (Zod) and config reading pipeline
- Add `prewarm` to `providerSchema` (Zod) and ProviderConfig construction
- Both fields were defined in `types.ts` but silently stripped by Zod's default strip mode

## Impact
- `speculativeDelayFactor` in YAML config now actually affects adaptive delay calculation (was hardcoded to 0.5)
- `prewarm: false` in provider YAML config now actually skips connection pool warmup (was always true)

## Validated findings (not bugs)
- CV threshold boundary (cv=0.5 → 2 copies): intentional per comment at hedging.ts:158
- Timeout boost stale on reload: provider objects replaced on reload, boost implicitly reset

## Test plan
- [x] All 386 tests pass
- [ ] Add `speculativeDelayFactor: 0.3` to YAML and verify it takes effect via /api/hedging/stats
- [ ] Add `prewarm: false` to a provider and verify it skips warmup on startup