### PR TITLE
feat: add 3-level concurrency control (provider+model, model, tier)

### DIFF
--- a/src/concurrency.ts
+++ b/src/concurrency.ts
@@ -1,0 +1,96 @@
+import type { ConcurrencyConfig } from "./types.js";
+
+export class Semaphore {
+  private queue: Array<{ resolve: (slot: number) => void; timer?: ReturnType<typeof setTimeout> }> = [];
+  private current = 0;
+
+  constructor(private max: number) {}
+
+  async acquire(timeoutMs?: number): Promise<boolean> {
+    if (this.current < this.max) {
+      this.current++;
+      return true;
+    }
+
+    if (timeoutMs === undefined || timeoutMs <= 0) {
+      return new Promise<boolean>((resolve) => {
+        this.queue.push({ resolve: () => { this.current++; resolve(true); } });
+      });
+    }
+
+    return new Promise<boolean>((resolve) => {
+      const timer = setTimeout(() => {
+        const idx = this.queue.findIndex((w) => w.resolve === onAcquire);
+        if (idx !== -1) this.queue.splice(idx, 1);
+        resolve(false);
+      }, timeoutMs);
+
+      const onAcquire = () => { this.current++; resolve(true); };
+      this.queue.push({ resolve: onAcquire, timer });
+    });
+  }
+
+  release(): void {
+    if (this.current > 0) this.current--;
+    const next = this.queue.shift();
+    if (next) {
+      if (next.timer) clearTimeout(next.timer);
+      next.resolve(0);
+    }
+  }
+}
+
+const semaphores = new Map<string, Semaphore>();
+
+/**
+ * Resolve concurrency config for a request.
+ * Lookup order: provider+model → model → tier → none.
+ * Returns the key (for semaphore lookup) and the config, or null if no limit applies.
+ */
+export function resolveConcurrency(
+  model: string,
+  tier: string,
+  provider?: string,
+  providerConcurrency?: Map<string, ConcurrencyConfig>,
+  modelConcurrency?: Map<string, ConcurrencyConfig>,
+  tierConcurrency?: Map<string, ConcurrencyConfig>,
+): { key: string; config: ConcurrencyConfig } | null {
+  // 1. Provider+model level (most specific)
+  if (provider) {
+    const pmKey = `${provider}:${model}`;
+    const pmConfig = providerConcurrency?.get(pmKey);
+    if (pmConfig && pmConfig.max_inflight > 0) {
+      return { key: `pm:${pmKey}`, config: pmConfig };
+    }
+  }
+
+  // 2. Model level
+  const modelConfig = modelConcurrency?.get(model);
+  if (modelConfig && modelConfig.max_inflight > 0) {
+    return { key: `model:${model}`, config: modelConfig };
+  }
+
+  // 3. Tier level (broadest)
+  const tierConfig = tierConcurrency?.get(tier);
+  if (tierConfig && tierConfig.max_inflight > 0) {
+    return { key: `tier:${tier}`, config: tierConfig };
+  }
+
+  return null;
+}
+
+/**
+ * Get or create a semaphore for the given key.
+ */
+export function getSemaphore(key: string, maxInflight: number): Semaphore {
+  let sem = semaphores.get(key);
+  if (!sem) {
+    sem = new Semaphore(maxInflight);
+    semaphores.set(key, sem);
+  }
+  return sem;
+}
+
+export function resetSemaphores(): void {
+  semaphores.clear();
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 import { parse as parseYaml } from "yaml";
 import { z } from "zod";
 import { CircuitBreaker } from "./circuit-breaker.js";
-import type { AppConfig, ClassificationRule, HedgingConfig, ProviderConfig, RoutingEntry, ServerConfig, SmartRoutingConfig } from "./types.js";
+import type { AppConfig, ClassificationRule, ConcurrencyConfig, HedgingConfig, ProviderConfig, RoutingEntry, ServerConfig, SmartRoutingConfig } from "./types.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -214,6 +214,18 @@ const rawConfigSchema = z.object({
   modelRouting: z.record(z.string(), z.array(routingEntrySchema)).default({}),
   hedging: hedgingSchema.optional(),
   smartRouting: smartRoutingSchema.optional(),
+  tierConcurrency: z.record(z.string(), z.object({
+    max_inflight: z.number().int().min(0),
+    queueTimeoutMs: z.number().int().min(1000).default(30000),
+  })).default({}),
+  modelConcurrency: z.record(z.string(), z.object({
+    max_inflight: z.number().int().min(0),
+    queueTimeoutMs: z.number().int().min(1000).default(30000),
+  })).default({}),
+  providerConcurrency: z.record(z.string(), z.object({
+    max_inflight: z.number().int().min(0),
+    queueTimeoutMs: z.number().int().min(1000).default(30000),
+  })).default({}),
 });
 
 // --- Env var resolution ---
@@ -601,6 +613,15 @@ export async function loadConfig(configPath?: string, cwd?: string): Promise<{ c
       maxHedge: validated.hedging.maxHedge,
     } : undefined,
     smartRouting: compileSmartRouting(validated.smartRouting),
+    tierConcurrency: Object.keys(validated.tierConcurrency).length > 0
+      ? new Map(Object.entries(validated.tierConcurrency) as [string, ConcurrencyConfig][])
+      : undefined,
+    modelConcurrency: Object.keys(validated.modelConcurrency).length > 0
+      ? new Map(Object.entries(validated.modelConcurrency) as [string, ConcurrencyConfig][])
+      : undefined,
+    providerConcurrency: Object.keys(validated.providerConcurrency).length > 0
+      ? new Map(Object.entries(validated.providerConcurrency) as [string, ConcurrencyConfig][])
+      : undefined,
   };
 
   // Cross-validate smart routing tier references against routing entries

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@ import { SessionAgentPool, DEFAULT_STALE_AGENT_THRESHOLD_MS } from "./session-po
 import { createLogger, type LogLevel } from "./logger.js";
 import type { AppConfig, ProviderConfig, RequestContext, StreamState } from "./types.js";
 import { transitionStreamState } from "./types.js";
+import { resolveConcurrency, getSemaphore, resetSemaphores } from "./concurrency.js";
 import { randomUUID } from "node:crypto";
 import { gzip } from "node:zlib";
 import { promisify } from "node:util";
@@ -614,6 +615,27 @@ export function createApp(initConfig: AppConfig, logLevel: LogLevel, metricsStor
     // Forward with fallback chain
     let successfulProvider = "unknown";
     let result: FallbackResult;
+    const conc = resolveConcurrency(ctx.model, ctx.tier, ctx.providerChain[0]?.provider, config.providerConcurrency, config.modelConcurrency, config.tierConcurrency);
+    const sem = conc ? getSemaphore(conc.key, conc.config.max_inflight) : null;
+    const acquired = sem ? await sem.acquire(conc!.config.queueTimeoutMs) : true;
+    if (!acquired) {
+      return new Response(
+        JSON.stringify({
+          type: "error",
+          error: {
+            type: "api_error",
+            message: `Concurrency limit reached for "${conc!.key}" (${conc!.config.max_inflight} inflight). Retry after queue timeout.`,
+          },
+        }),
+        {
+          status: 503,
+          headers: {
+            "content-type": "application/json",
+            "retry-after": String(Math.ceil(conc!.config.queueTimeoutMs / 1000)),
+          },
+        },
+      );
+    }
     inFlightCount++;
     try {
       result = await forwardWithFallback(
@@ -650,6 +672,7 @@ export function createApp(initConfig: AppConfig, logLevel: LogLevel, metricsStor
         502
       );
     } finally {
+      if (sem) sem.release();
       inFlightCount--;
     }
 
@@ -939,6 +962,7 @@ export function createApp(initConfig: AppConfig, logLevel: LogLevel, metricsStor
       activeProbeManager.updateProviders(newConfig.providers);
       clearRoutingCache();
       clearHedgeStats();
+      resetSemaphores();
 
       // Update session pool thresholds from new config
       const newIdleTtl = newConfig.server?.sessionIdleTtlMs ?? 600_000;

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,11 @@ export interface ClassificationRule {
   _compiled?: RegExp;
 }
 
+export interface ConcurrencyConfig {
+  max_inflight: number;
+  queueTimeoutMs: number;
+}
+
 export interface SmartRoutingConfig {
   /** Master switch — when false, smart routing is skipped entirely */
   enabled: boolean;
@@ -105,6 +110,9 @@ export interface AppConfig {
   modelRouting: Map<string, RoutingEntry[]>;
   hedging?: HedgingConfig;
   smartRouting?: SmartRoutingConfig;
+  tierConcurrency?: Map<string, ConcurrencyConfig>;
+  modelConcurrency?: Map<string, ConcurrencyConfig>;
+  providerConcurrency?: Map<string, ConcurrencyConfig>;
 }
 
 export interface RequestContext {

--- a/tests/concurrency.test.ts
+++ b/tests/concurrency.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Semaphore, getSemaphore, resolveConcurrency, resetSemaphores } from "../src/concurrency.js";
+import type { ConcurrencyConfig } from "../src/types.js";
+
+describe("Semaphore", () => {
+  let sem: Semaphore;
+
+  beforeEach(() => {
+    sem = new Semaphore(1);
+  });
+
+  it("acquires immediately when under limit", async () => {
+    const acquired = await sem.acquire(1000);
+    expect(acquired).toBe(true);
+  });
+
+  it("queues when at limit and resolves on release", async () => {
+    await sem.acquire(1000);
+    const p = sem.acquire(5000);
+    sem.release();
+    expect(await p).toBe(true);
+  });
+
+  it("rejects on timeout", async () => {
+    await sem.acquire(1000);
+    const acquired = await sem.acquire(50);
+    expect(acquired).toBe(false);
+  });
+
+  it("handles multiple queued waiters in FIFO order", async () => {
+    const sem2 = new Semaphore(1);
+    await sem2.acquire(1000);
+
+    const results: boolean[] = [];
+    const p1 = sem2.acquire(2000).then((r) => results.push(r));
+    const p2 = sem2.acquire(2000).then((r) => results.push(r));
+    const p3 = sem2.acquire(2000).then((r) => results.push(r));
+
+    sem2.release();
+    await p1;
+    sem2.release();
+    await p2;
+    sem2.release();
+    await p3;
+
+    expect(results).toEqual([true, true, true]);
+  });
+
+  it("cleans up timed-out waiters from queue", async () => {
+    await sem.acquire(1000);
+    await sem.acquire(50);
+    expect((sem as any).queue.length).toBe(0);
+  });
+});
+
+describe("resolveConcurrency", () => {
+  beforeEach(() => {
+    resetSemaphores();
+  });
+
+  it("returns null when no config provided", () => {
+    expect(resolveConcurrency("glm-5.1", "tier1")).toBeNull();
+  });
+
+  it("prefers provider+model over model level", () => {
+    const providerConfig = new Map<string, ConcurrencyConfig>();
+    providerConfig.set("glm:glm-5.1", { max_inflight: 1, queueTimeoutMs: 10000 });
+    const modelConfig = new Map<string, ConcurrencyConfig>();
+    modelConfig.set("glm-5.1", { max_inflight: 4, queueTimeoutMs: 30000 });
+
+    const result = resolveConcurrency("glm-5.1", "tier1", "glm", providerConfig, modelConfig);
+    expect(result!.key).toBe("pm:glm:glm-5.1");
+    expect(result!.config.max_inflight).toBe(1);
+  });
+
+  it("prefers model over tier when no provider config", () => {
+    const modelConfig = new Map<string, ConcurrencyConfig>();
+    modelConfig.set("glm-5.1", { max_inflight: 1, queueTimeoutMs: 10000 });
+    const tierConfig = new Map<string, ConcurrencyConfig>();
+    tierConfig.set("tier1", { max_inflight: 4, queueTimeoutMs: 30000 });
+
+    const result = resolveConcurrency("glm-5.1", "tier1", "glm", undefined, modelConfig, tierConfig);
+    expect(result!.key).toBe("model:glm-5.1");
+    expect(result!.config.max_inflight).toBe(1);
+  });
+
+  it("falls back to tier when no model config", () => {
+    const tierConfig = new Map<string, ConcurrencyConfig>();
+    tierConfig.set("tier1", { max_inflight: 2, queueTimeoutMs: 30000 });
+
+    const result = resolveConcurrency("glm-5.1", "tier1", "glm", undefined, undefined, tierConfig);
+    expect(result!.key).toBe("tier:tier1");
+    expect(result!.config.max_inflight).toBe(2);
+  });
+
+  it("returns null when max_inflight is 0", () => {
+    const modelConfig = new Map<string, ConcurrencyConfig>();
+    modelConfig.set("glm-5.1", { max_inflight: 0, queueTimeoutMs: 30000 });
+
+    const result = resolveConcurrency("glm-5.1", "tier1", undefined, undefined, modelConfig);
+    expect(result).toBeNull();
+  });
+
+  it("different providers get independent semaphores", () => {
+    const providerConfig = new Map<string, ConcurrencyConfig>();
+    providerConfig.set("glm:glm-5.1", { max_inflight: 1, queueTimeoutMs: 10000 });
+    providerConfig.set("glm_openai:glm-5.1", { max_inflight: 3, queueTimeoutMs: 15000 });
+
+    const r1 = resolveConcurrency("glm-5.1", "tier1", "glm", providerConfig);
+    const r2 = resolveConcurrency("glm-5.1", "tier1", "glm_openai", providerConfig);
+
+    const s1 = getSemaphore(r1!.key, r1!.config.max_inflight);
+    const s2 = getSemaphore(r2!.key, r2!.config.max_inflight);
+    expect(s1).not.toBe(s2);
+  });
+
+  it("skips provider level when provider is undefined", () => {
+    const modelConfig = new Map<string, ConcurrencyConfig>();
+    modelConfig.set("glm-5.1", { max_inflight: 2, queueTimeoutMs: 30000 });
+
+    const result = resolveConcurrency("glm-5.1", "tier1", undefined, undefined, modelConfig);
+    expect(result!.key).toBe("model:glm-5.1");
+  });
+});
+
+describe("getSemaphore", () => {
+  beforeEach(() => {
+    resetSemaphores();
+  });
+
+  it("returns same semaphore for same key", () => {
+    const a = getSemaphore("tier:tier1", 1);
+    const b = getSemaphore("tier:tier1", 1);
+    expect(a).toBe(b);
+  });
+
+  it("returns different semaphores for different keys", () => {
+    const a = getSemaphore("pm:glm:glm-5.1", 1);
+    const b = getSemaphore("pm:glm_openai:glm-5.1", 3);
+    expect(a).not.toBe(b);
+  });
+
+  it("resetSemaphores clears all semaphores", () => {
+    const a = getSemaphore("tier:tier1", 1);
+    resetSemaphores();
+    const b = getSemaphore("tier:tier1", 1);
+    expect(a).not.toBe(b);
+  });
+});


### PR DESCRIPTION
## Summary
- New `Semaphore` class with timeout-based queueing (`src/concurrency.ts`)
- 3-level concurrency resolution: `provider+model` → `model` → `tier` → none
- Config via `tierConcurrency`, `modelConcurrency`, `providerConcurrency` in YAML
- `max_inflight: 0` disables the limit at any level
- 503 with `Retry-After` header when queue timeout expires
- Semaphores reset on config reload

## Config example
```yaml
providerConcurrency:
  glm:glm-5.1:
    max_inflight: 1
    queueTimeoutMs: 30000
  glm_openai:glm-5.1:
    max_inflight: 2
    queueTimeoutMs: 15000

modelConcurrency:
  glm-5.1:
    max_inflight: 1
    queueTimeoutMs: 30000

tierConcurrency:
  tier1:
    max_inflight: 0  # disabled, fall through to model level
    queueTimeoutMs: 30000
```

## Test plan
- [x] 15 unit tests covering semaphore acquire/release/timeout/FIFO and 3-level resolution
- [x] Live validated: `glm-5.1` serialized at model level (`max_inflight=1`)
- [x] Live validated: `glm_openai:glm-5.1` allows 2 concurrent via provider level
- [x] Live validated: 503 with `Retry-After` header when queue timeout expires
- [x] `max_inflight: 0` correctly skips concurrency check
