### PR TITLE
fix: clear stall timer in ReadableStream cancel() path

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1903,6 +1903,9 @@ export async function forwardRequest(
         if (upstreamBody && !upstreamBody.destroyed) {
           (upstreamBody as any)._intentionalClose = true;
         }
+        // Clear stall timer — destroy() skips "end" event so the normal cleanup
+        // path is unreachable. Without this, the interval leaks on client disconnect.
+        if (stallTimerRef) { clearInterval(stallTimerRef); stallTimerRef = undefined; }
         if (passThrough) {
           (passThrough as any)._intentionalClose = true;
           try { passThrough.destroy(); } catch { /* already done */ }


### PR DESCRIPTION
## Summary
- `cancel()` calls `passThrough.destroy()` which skips the `"end"` event, so the stall timer cleanup in the `"end"` handler is never reached
- The `setInterval` keeps firing indefinitely, holding references to the stream and closures, preventing GC
- Add explicit `clearInterval(stallTimerRef)` before `destroy()` in the `cancel()` callback

Closes #306

## Test plan
- [x] All 401 tests pass
- [x] `npx tsc --noEmit` clean
- [ ] Verify streaming via daemon reload — confirm no timer leaks on client disconnect