### PR TITLE
fix: reconstruct Response after consuming body in forwardWithRetry

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2171,7 +2171,14 @@ async function forwardWithRetry(
   // Stall errors are recorded in handleStall() (per-request, no retry amplification).
 
   console.warn(`[proxy] All ${maxRetries + 1} attempts failed for "${provider.name}" — escalating to fallback`);
-  return lastResult!;
+  // Reconstruct Response — lastResult's body was consumed by .text() above.
+  // Caller (forwardWithFallback, race) needs a readable body for isConnectionErrorBody()
+  // and health scoring. Without this, clone() throws on consumed body, causing
+  // connection errors to be misclassified as real upstream 502s.
+  return new Response(lastBody, {
+    status: lastResult!.status,
+    headers: lastResult!.headers,
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary
- `forwardWithRetry` calls `lastResult!.text()` at L2168 to record metrics, consuming the body
- The returned `lastResult!` then has an unreadable body — `clone()` throws in callers
- `isConnectionErrorBody()` catches the error and returns `false`, misclassifying connection errors as real upstream 502s
- This causes health scoring to penalize connection timeouts/stalls as real failures

**Fix**: Reconstruct a fresh `Response` from the consumed text before returning.

Closes #307

## Test plan
- [x] All 401 tests pass
- [x] `npx tsc --noEmit` clean
- [ ] Verify circuit breaker and health scoring via daemon reload under failure conditions