### PR TITLE
feat: add compressOldTurns to skeleton old conversation turns

### DIFF
--- a/modelweaver.example.yaml
+++ b/modelweaver.example.yaml
@@ -79,6 +79,10 @@ routing:
   sonnet:
     - provider: anthropic
       model: claude-sonnet-4-20250514
+      # Context management — reduce tokens sent to provider:
+      # compressOldTurns: 10   # keep last 10 turns verbatim, skeleton older ones
+      # maxContextMessages: 60 # hard limit on total messages (runs after compression)
+      # toolResultLimit: 8000  # max chars per tool_result block
     - provider: openrouter
       model: anthropic/claude-sonnet-4
   opus:

--- a/src/config.ts
+++ b/src/config.ts
@@ -138,6 +138,7 @@ const providerSchema = z.object({
   concurrentLimit: z.number().int().min(1).optional(),
   maxContextMessages: z.number().int().positive().optional(),
   toolResultLimit: z.number().int().positive().optional(),
+  compressOldTurns: z.number().int().positive().optional(),
   poolSize: z.number().int().min(1).max(100).optional(),
   modelPools: z.record(z.string(), z.number().int().min(1).max(50)).optional(),
   connectionRetries: z.number().int().min(0).max(10).optional(),
@@ -541,6 +542,7 @@ export async function loadConfig(configPath?: string, cwd?: string): Promise<{ c
       modelPools: p.modelPools !== undefined ? { ...p.modelPools } : undefined,
       maxContextMessages: p.maxContextMessages,
       toolResultLimit: p.toolResultLimit,
+      compressOldTurns: p.compressOldTurns,
       prewarm: p.prewarm,
     };
     try {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -665,6 +665,120 @@ const COMPRESSORS: Record<CompressionBucket, (text: string, limit: number, toolN
   default: compressDefault,
 };
 
+/**
+ * Compress old conversation turns to skeleton summaries.
+ * Keeps the most recent `keepTurns` turns verbatim. Older turns are replaced with
+ * one-line summaries (role structure preserved). Tool chain messages (tool_use,
+ * tool_result pairs) in old turns are removed entirely — the assistant skeleton
+ * mentions which tools were used.
+ *
+ * Mutates body.messages in-place. Run cleanOrphanedToolMessages() after.
+ */
+export function compressOldTurns(body: Record<string, unknown>, keepTurns: number): void {
+  const messages = body.messages as any[] | undefined;
+  if (!Array.isArray(messages) || messages.length === 0) return;
+
+  // Identify turn boundaries: a "turn" starts at each user text message
+  // (not tool_result, not injected hint)
+  const isTurnStart = (msg: any): boolean => {
+    if (msg.role !== "user") return false;
+    if (Array.isArray(msg.content) && msg.content.some((b: any) => b?.type === "tool_result")) return false;
+    if (Array.isArray(msg.content) && msg.content.length === 1 && msg.content[0]?.type === "text" &&
+        typeof msg.content[0].text === "string" && msg.content[0].text.startsWith("[System:")) return false;
+    return true;
+  };
+
+  // Collect turn boundary indices
+  const turnStarts: number[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    if (isTurnStart(messages[i])) turnStarts.push(i);
+  }
+
+  // Nothing to compress if we're within the limit
+  if (turnStarts.length <= keepTurns) return;
+
+  // Determine which turns to compress: all except the last `keepTurns`
+  const firstKeptTurnIdx = turnStarts.length - keepTurns;
+
+  // Build index of which message indices belong to old turns (before firstKeptMsgIdx)
+  // For each old turn, we'll generate a skeleton pair: user summary + assistant summary
+  const skeletons: any[] = [];
+  const removeIndices = new Set<number>();
+
+  for (let t = 0; t < firstKeptTurnIdx; t++) {
+    const start = turnStarts[t];
+    const end = t + 1 < turnStarts.length ? turnStarts[t + 1] : messages.length;
+
+    // Collect this turn's messages
+    let userPreview = "";
+    let assistantToolNames: string[] = [];
+    let assistantTextPreview = "";
+
+    for (let i = start; i < end; i++) {
+      const msg = messages[i];
+      removeIndices.add(i);
+
+      // Extract user text preview
+      if (msg.role === "user") {
+        const text = typeof msg.content === "string" ? msg.content :
+          Array.isArray(msg.content) ? msg.content
+            .filter((b: any) => b?.type === "text")
+            .map((b: any) => b.text)
+            .join("") : "";
+        userPreview = text.slice(0, 80);
+      }
+
+      // Extract assistant info
+      if (msg.role === "assistant" && Array.isArray(msg.content)) {
+        for (const block of msg.content) {
+          if (block.type === "tool_use" && block.name) {
+            assistantToolNames.push(block.name);
+          }
+          if (block.type === "text" && block.text && !assistantTextPreview) {
+            assistantTextPreview = String(block.text).slice(0, 60);
+          }
+        }
+      }
+    }
+
+    // Build skeleton user message
+    const userText = userPreview
+      ? `[Earlier: user asked "${userPreview}${userPreview.length >= 80 ? "..." : ""}"]`
+      : "[Earlier: user message]";
+    skeletons.push({
+      role: "user",
+      content: [{ type: "text", text: userText }],
+    });
+
+    // Build skeleton assistant message
+    let assistantText: string;
+    if (assistantToolNames.length > 0) {
+      assistantText = `[Earlier: assistant used ${assistantToolNames.join(", ")}]`;
+    } else if (assistantTextPreview) {
+      assistantText = `[Earlier: assistant responded "${assistantTextPreview}..."]`;
+    } else {
+      assistantText = "[Earlier: assistant responded]";
+    }
+    skeletons.push({
+      role: "assistant",
+      content: [{ type: "text", text: assistantText }],
+    });
+  }
+
+  // Splice: replace old messages with skeletons + kept messages
+  // No hint message — skeletons use "[Earlier: ...]" prefix to signal compression.
+  // A hint message would break role alternation (user→user with first kept message).
+  const keptMessages = messages.filter((_: any, i: number) => !removeIndices.has(i));
+  const newMessages = [...skeletons, ...keptMessages];
+
+  (body as any).messages = newMessages;
+
+  const compressedCount = removeIndices.size;
+  console.warn(
+    `[context-compress] Compressed ${firstKeptTurnIdx} old turns (${compressedCount} messages) to ${skeletons.length} skeleton messages, kept ${keptMessages.length} verbatim (limit: ${keepTurns} turns)`,
+  );
+}
+
 function compressToolResults(body: Record<string, unknown>, limit: number): void {
   const messages = body.messages;
   if (!Array.isArray(messages)) return;
@@ -739,6 +853,7 @@ function applyTargetedReplacements(
     if (entry.model) mutable.model = entry.model;
     if (needsOrphanClean) cleanOrphanedToolMessages(mutable);
     if (provider.toolResultLimit) compressToolResults(mutable, provider.toolResultLimit);
+    if (provider.compressOldTurns) compressOldTurns(mutable, provider.compressOldTurns);
     if (provider.modelLimits) {
       const { maxOutputTokens } = provider.modelLimits;
       const requested = typeof mutable.max_tokens === "number" ? mutable.max_tokens : maxOutputTokens;
@@ -901,9 +1016,13 @@ export async function forwardRequest(
       if (needsThinkingStrip) needsModification = true;
 
       // Check 5: Tool result compression needed?
-      // Only trigger full mutation when tool_result blocks actually exist AND are oversized.
+      // Only trigger full mutation when tool_result blocks actually exist AND are oversized,
+      // or when turn compression is configured.
       // Avoids forcing JSON.stringify on every request (breaks prompt cache).
       let needsCompression = false;
+      if (provider.compressOldTurns) {
+        needsCompression = true;
+      }
       if (provider.toolResultLimit && Array.isArray(parsed.messages)) {
         for (const msg of parsed.messages) {
           if (msg.role !== "user" || !Array.isArray(msg.content)) continue;
@@ -956,6 +1075,10 @@ export async function forwardRequest(
 
           if (provider.toolResultLimit) {
             compressToolResults(mutable, provider.toolResultLimit);
+          }
+
+          if (provider.compressOldTurns) {
+            compressOldTurns(mutable, provider.compressOldTurns);
           }
 
           if (provider.modelLimits) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,8 @@ export interface ProviderConfig {
   maxContextMessages?: number;
   /** Max characters per tool_result content block. Head+tail truncation if exceeded. */
   toolResultLimit?: number;
+  /** Number of recent turns to keep verbatim. Older turns are compressed to skeleton summaries. */
+  compressOldTurns?: number;
 
   /** Runtime-only cached fields — not serialized to config */
   _cachedHost?: string;

--- a/tests/compress-old-turns.test.ts
+++ b/tests/compress-old-turns.test.ts
@@ -1,0 +1,329 @@
+// tests/compress-old-turns.test.ts
+import { describe, it, expect } from "vitest";
+import { compressOldTurns } from "../src/proxy.js";
+
+/** Helper: build a user text message */
+function userMsg(text: string) {
+  return { role: "user", content: [{ type: "text", text }] };
+}
+
+/** Helper: build an assistant text message */
+function assistantMsg(text: string) {
+  return { role: "assistant", content: [{ type: "text", text }] };
+}
+
+/** Helper: build an assistant message with tool_use blocks */
+function assistantToolMsg(toolCalls: { id: string; name: string; input?: any }[]) {
+  return {
+    role: "assistant",
+    content: toolCalls.map(tc => ({
+      type: "tool_use",
+      id: tc.id,
+      name: tc.name,
+      input: tc.input ?? {},
+    })),
+  };
+}
+
+/** Helper: build a user message with tool_result blocks */
+function toolResultMsg(results: { toolUseId: string; content: string }[]) {
+  return {
+    role: "user",
+    content: results.map(r => ({
+      type: "tool_result",
+      tool_use_id: r.toolUseId,
+      content: r.content,
+    })),
+  };
+}
+
+/** Helper: create body with messages array */
+function makeBody(messages: any[]) {
+  return { messages: structuredClone(messages) };
+}
+
+describe("compressOldTurns", () => {
+  it("skips when messages count is zero", () => {
+    const body = makeBody([]);
+    compressOldTurns(body, 5);
+    expect(body.messages).toEqual([]);
+  });
+
+  it("skips when turn count is within limit", () => {
+    const msgs = [
+      userMsg("hello"),
+      assistantMsg("hi there"),
+    ];
+    const body = makeBody(msgs);
+    compressOldTurns(body, 5);
+    expect(body.messages).toEqual(msgs);
+  });
+
+  it("skips when turn count equals limit", () => {
+    const msgs = [
+      userMsg("turn 1"),
+      assistantMsg("response 1"),
+      userMsg("turn 2"),
+      assistantMsg("response 2"),
+    ];
+    const body = makeBody(msgs);
+    compressOldTurns(body, 2);
+    // 2 turns === limit, no compression needed
+    expect(body.messages).toEqual(msgs);
+  });
+
+  it("compresses old turns to skeletons and keeps recent turns verbatim", () => {
+    const msgs = [
+      userMsg("turn 1 question"),
+      assistantMsg("turn 1 answer"),
+      userMsg("turn 2 question"),
+      assistantMsg("turn 2 answer"),
+      userMsg("turn 3 question"),
+      assistantMsg("turn 3 answer"),
+    ];
+    const body = makeBody(msgs);
+    compressOldTurns(body, 1); // keep only last 1 turn
+
+    const result = body.messages;
+
+    // Should have: skeleton for turn1 + skeleton for turn2 + turn3 user + turn3 assistant
+    // 2 skeleton pairs (4 msgs) + 2 kept = 6
+    expect(result.length).toBe(6);
+
+    // First skeleton user
+    expect(result[0].role).toBe("user");
+    expect(result[0].content[0].text).toContain("turn 1 question");
+
+    // First skeleton assistant
+    expect(result[1].role).toBe("assistant");
+    expect(result[1].content[0].text).toContain("[Earlier:");
+
+    // Second skeleton pair
+    expect(result[2].role).toBe("user");
+    expect(result[3].role).toBe("assistant");
+
+    // Kept turn 3 verbatim
+    expect(result[4]).toEqual(userMsg("turn 3 question"));
+    expect(result[5]).toEqual(assistantMsg("turn 3 answer"));
+  });
+
+  it("preserves role alternation in output", () => {
+    const msgs = [
+      userMsg("q1"), assistantMsg("a1"),
+      userMsg("q2"), assistantMsg("a2"),
+      userMsg("q3"), assistantMsg("a3"),
+      userMsg("q4"), assistantMsg("a4"),
+    ];
+    const body = makeBody(msgs);
+    compressOldTurns(body, 2);
+
+    // Verify strict alternation
+    for (let i = 0; i < body.messages.length; i++) {
+      const expectedRole = i % 2 === 0 ? "user" : "assistant";
+      expect(body.messages[i].role).toBe(expectedRole);
+    }
+  });
+
+  it("removes tool chain messages from old turns", () => {
+    const msgs = [
+      userMsg("write a function"),
+      assistantToolMsg([{ id: "call_1", name: "Write" }]),
+      toolResultMsg([{ toolUseId: "call_1", content: "file written" }]),
+      assistantMsg("done writing"),
+      userMsg("now test it"),
+      assistantToolMsg([{ id: "call_2", name: "Bash" }]),
+      toolResultMsg([{ toolUseId: "call_2", content: "tests pass" }]),
+      assistantMsg("all tests pass"),
+    ];
+    const body = makeBody(msgs);
+    compressOldTurns(body, 1); // keep only last turn ("now test it" onwards)
+
+    const result = body.messages;
+
+    // Old turn skeleton should mention "Write" tool
+    const skeletonTexts = result.slice(0, 2).map((m: any) =>
+      m.content.map((b: any) => b.text).join(""),
+    ).join(" ");
+    expect(skeletonTexts).toContain("Write");
+
+    // Kept turn should be verbatim (userMsg + assistant tool chain + tool_result + assistant)
+    const kept = result.slice(2); // after skeletons
+    expect(kept[0]).toEqual(userMsg("now test it"));
+    expect(kept[1]).toEqual(assistantToolMsg([{ id: "call_2", name: "Bash" }]));
+  });
+
+  it("handles user messages with string content (not array)", () => {
+    const msgs = [
+      { role: "user", content: "simple string question" },
+      { role: "assistant", content: "simple answer" },
+      userMsg("turn 2"),
+      assistantMsg("answer 2"),
+    ];
+    const body = { messages: structuredClone(msgs) };
+    compressOldTurns(body, 1);
+
+    const result = body.messages as any[];
+    // First skeleton should extract the string content
+    expect(result[0].content[0].text).toContain("simple string question");
+  });
+
+  it("handles empty user message content", () => {
+    const msgs = [
+      { role: "user", content: "" },
+      { role: "assistant", content: "ok" },
+      userMsg("real question"),
+      assistantMsg("real answer"),
+    ];
+    const body = { messages: structuredClone(msgs) };
+    compressOldTurns(body, 1);
+
+    const result = body.messages as any[];
+    // Empty content → fallback to "[Earlier: user message]"
+    expect(result[0].content[0].text).toContain("[Earlier: user message]");
+  });
+
+  it("skips tool_result-only user messages as turn starts", () => {
+    // A conversation that starts with a tool_result (mid-chain) should NOT be treated as a turn start
+    const msgs = [
+      toolResultMsg([{ toolUseId: "call_1", content: "result" }]),
+      assistantMsg("continuing"),
+      userMsg("new turn"),
+      assistantMsg("response"),
+    ];
+    const body = makeBody(msgs);
+    compressOldTurns(body, 1);
+
+    const result = body.messages;
+    // tool_result message is NOT a turn start, so "new turn" is turn 1
+    // With keepTurns=1 and only 1 turn, nothing should be compressed
+    expect(result).toEqual(msgs);
+  });
+
+  it("skips injected hint messages as turn starts", () => {
+    const hintMsg = {
+      role: "user",
+      content: [{ type: "text", text: "[System: 5 earlier turns compressed to summaries]" }],
+    };
+    const msgs = [
+      hintMsg,
+      assistantMsg("continuing"),
+      userMsg("new question"),
+      assistantMsg("answer"),
+    ];
+    const body = makeBody(msgs);
+    compressOldTurns(body, 1);
+
+    // "new question" is the only real turn, so nothing to compress
+    expect(body.messages).toEqual(msgs);
+  });
+
+  it("truncates long user previews to 80 chars", () => {
+    const longText = "a".repeat(200);
+    const msgs = [
+      userMsg(longText),
+      assistantMsg("ok"),
+      userMsg("short"),
+      assistantMsg("done"),
+    ];
+    const body = makeBody(msgs);
+    compressOldTurns(body, 1);
+
+    const skeletonUser = body.messages[0];
+    const text = skeletonUser.content[0].text;
+    // The preview should contain at most 80 chars of the original + ellipsis
+    expect(text.length).toBeLessThan(120); // "[Earlier: user asked " + 80 + "...]"
+    expect(text).toContain("...");
+  });
+
+  it("mentions tool names in assistant skeleton", () => {
+    const msgs = [
+      userMsg("do stuff"),
+      assistantToolMsg([
+        { id: "c1", name: "Read" },
+        { id: "c2", name: "Edit" },
+      ]),
+      userMsg("more"),
+      assistantMsg("done"),
+    ];
+    const body = makeBody(msgs);
+    compressOldTurns(body, 1);
+
+    // Find the skeleton assistant for turn 1
+    const skeletonAssistant = body.messages[1];
+    const text = skeletonAssistant.content[0].text;
+    expect(text).toContain("Read");
+    expect(text).toContain("Edit");
+  });
+
+  it("handles assistant with text content when no tools used", () => {
+    const msgs = [
+      userMsg("explain something"),
+      assistantMsg("here is a detailed explanation that is quite long and goes on and on and on and on"),
+      userMsg("thanks"),
+      assistantMsg("you're welcome"),
+    ];
+    const body = makeBody(msgs);
+    compressOldTurns(body, 1);
+
+    const skeletonAssistant = body.messages[1];
+    const text = skeletonAssistant.content[0].text;
+    expect(text).toContain("[Earlier: assistant responded");
+    expect(text).toContain("here is a detailed explanation");
+  });
+
+  it("handles conversation with system prompt at start", () => {
+    const msgs = [
+      { role: "user", content: "system instruction" } as any,
+      userMsg("first question"),
+      assistantMsg("first answer"),
+      userMsg("second question"),
+      assistantMsg("second answer"),
+    ];
+    const body = makeBody(msgs);
+    compressOldTurns(body, 1);
+
+    // "system instruction" is the first turn, "first question" is second turn, "second question" is third
+    // With keepTurns=1, turns 1 and 2 get compressed
+    const result = body.messages;
+    // Should still have strict role alternation
+    for (let i = 0; i < result.length; i++) {
+      const expectedRole = i % 2 === 0 ? "user" : "assistant";
+      expect(result[i].role).toBe(expectedRole);
+    }
+  });
+
+  it("does not mutate original messages array", () => {
+    const original = [
+      userMsg("q1"), assistantMsg("a1"),
+      userMsg("q2"), assistantMsg("a2"),
+    ];
+    const originalCopy = structuredClone(original);
+    const body = makeBody(original);
+    compressOldTurns(body, 1);
+
+    // The input array objects should not be modified (body.messages is a new array)
+    // But verify the original messages' content wasn't mutated
+    expect(original[0].content[0].text).toBe(originalCopy[0].content[0].text);
+    expect(original[1].content[0].text).toBe(originalCopy[1].content[0].text);
+  });
+
+  it("handles single turn conversation (no compression needed)", () => {
+    const msgs = [
+      userMsg("hello"),
+      assistantMsg("hi"),
+    ];
+    const body = makeBody(msgs);
+    compressOldTurns(body, 5);
+    expect(body.messages).toEqual(msgs);
+  });
+
+  it("handles non-array messages gracefully", () => {
+    const body = { messages: "not an array" } as any;
+    expect(() => compressOldTurns(body, 5)).not.toThrow();
+  });
+
+  it("handles missing messages field gracefully", () => {
+    const body = {} as any;
+    expect(() => compressOldTurns(body, 5)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- New `compressOldTurns` per-provider config that keeps the last N conversation turns verbatim while compressing older turns to lightweight skeleton summaries
- Skeletons contain user message preview (truncated to 80 chars) + assistant summary with tool names used, preserving role alternation
- Pipeline: `compressToolResults` → `compressOldTurns` → `maxContextMessages`

## Changes
- `src/types.ts` — Added `compressOldTurns?: number` to ProviderConfig
- `src/config.ts` — Added to Zod schema with propagation
- `src/proxy.ts` — New exported `compressOldTurns()` function + pipeline integration in both streaming and non-streaming paths
- `modelweaver.example.yaml` — Config documentation for all three context management options
- `tests/compress-old-turns.test.ts` — 18 tests covering edge cases, role alternation, tool chains, content types

## Bug fixed during development
- Removed hint message that caused role alternation violation (consecutive user→user messages that Anthropic API rejects)

## Test plan
- [x] 18 new unit tests pass (edge cases, role alternation, tool chains, content types)
- [x] Full suite: 422/422 tests pass
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Manual: configure `compressOldTurns: 3` on a provider and verify long conversations get skeleton'd correctly
- [ ] Manual: verify no role alternation errors from upstream API