### PR TITLE
fix: prevent double-injection of skeleton events on empty upstream responses

### DIFF
--- a/src/adapters/openai-utils.ts
+++ b/src/adapters/openai-utils.ts
@@ -406,6 +406,10 @@ export function createOpenAIChatToAnthropicStream() {
   let currentBlockType: "text" | "thinking" | null = null;
   let currentBlockIndex = 0;
   let hasToolCalls = false;
+  // Track whether any real content (text, thinking, tool_use) was emitted.
+  // When upstream drops without content, emit nothing so the proxy's
+  // empty-response detection returns 502 instead of double-injecting events.
+  let hadRealContent = false;
 
   // Track tool calls by OpenAI index → block index mapping
   const toolBlockIndices = new Map<number, number>();
@@ -500,11 +504,11 @@ export function createOpenAIChatToAnthropicStream() {
     const choice = parsed.choices?.[0];
     if (!choice) return;
 
-    emitMessageStart(push);
     const delta = choice.delta;
-
     // Handle reasoning_content -> thinking block
     if (delta?.reasoning_content) {
+      hadRealContent = true;
+      emitMessageStart(push);
       // Close text block if we're transitioning from text to thinking
       if (currentBlockType === "text") {
         closeCurrentBlock(push);
@@ -531,6 +535,8 @@ export function createOpenAIChatToAnthropicStream() {
 
     // Handle text content
     if (delta?.content) {
+      hadRealContent = true;
+      emitMessageStart(push);
       // Close thinking block if we're transitioning from thinking to text
       if (currentBlockType === "thinking") {
         closeCurrentBlock(push);
@@ -557,6 +563,8 @@ export function createOpenAIChatToAnthropicStream() {
 
     // Handle tool_calls
     if (delta?.tool_calls) {
+      hadRealContent = true;
+      emitMessageStart(push);
       for (const tc of delta.tool_calls) {
         const tcIndex = tc.index ?? 0;
 
@@ -626,8 +634,13 @@ export function createOpenAIChatToAnthropicStream() {
 
         const data = trimmed.startsWith("data: ") ? trimmed.slice(6).trim() : trimmed.slice(5).trim();
         if (data === "[DONE]") {
-          emitMessageStart(push);
-          emitClosingEvents(push, lastFinishReason ?? undefined);
+          // Only emit closing events if real content was processed.
+          // If upstream sent [DONE] with no content chunks, emit nothing
+          // so the proxy's empty-response detection returns 502 for fallback.
+          if (hadRealContent) {
+            emitMessageStart(push);
+            emitClosingEvents(push, lastFinishReason ?? undefined);
+          }
           callback();
           return;
         }
@@ -653,9 +666,14 @@ export function createOpenAIChatToAnthropicStream() {
     },
 
     flush(callback: () => void) {
-      const push = this.push.bind(this);
-      emitMessageStart(push);
-      emitClosingEvents(push);
+      // Only emit if real content was seen. When upstream drops without
+      // content (GOAWAY, TLS reset), emitting skeleton events causes the
+      // proxy's safeClose to double-inject, producing a malformed stream.
+      if (hadRealContent) {
+        const push = this.push.bind(this);
+        emitMessageStart(push);
+        emitClosingEvents(push);
+      }
       callback();
     },
   });
@@ -760,6 +778,7 @@ export function createOpenAIResponsesToAnthropicStream() {
   let started = false;
   let closed = false;
   let blockOpen = false;
+  let hadRealContent = false;
 
   type PushFn = (data: string) => boolean;
 
@@ -874,6 +893,7 @@ export function createOpenAIResponsesToAnthropicStream() {
 
         // response.output_text.delta → content_block_delta (text_delta)
         if (currentEvent === "response.output_text.delta" && parsed.delta !== undefined) {
+          hadRealContent = true;
           if (!started) emitMessageStart(push);
           if (!blockOpen) {
             blockOpen = true;
@@ -897,6 +917,7 @@ export function createOpenAIResponsesToAnthropicStream() {
 
         // response.function_call_arguments.delta → content_block_delta (input_json_delta)
         if (currentEvent === "response.function_call_arguments.delta" && parsed.delta !== undefined) {
+          hadRealContent = true;
           if (!started) emitMessageStart(push);
           push(
             `event: content_block_delta\ndata: ${JSON.stringify({
@@ -916,8 +937,10 @@ export function createOpenAIResponsesToAnthropicStream() {
 
         // response.completed → message_delta + message_stop
         if (currentEvent === "response.completed") {
-          emitMessageStart(push);
-          emitClosingEvents(push);
+          if (hadRealContent) {
+            emitMessageStart(push);
+            emitClosingEvents(push);
+          }
           continue;
         }
       }
@@ -925,22 +948,25 @@ export function createOpenAIResponsesToAnthropicStream() {
     },
 
     flush(callback: () => void) {
-      const push = this.push.bind(this);
-      // Process any remaining buffered line — extract usage before closing
-      if (lineBuffer.trim()) {
-        const line = lineBuffer.trim();
-        if (line.startsWith("data: ")) {
-          try {
-            const parsed = JSON.parse(line.slice(6).trim());
-            if (parsed?.usage?.input_tokens !== undefined) inputTokens = parsed.usage.input_tokens;
-            if (parsed?.usage?.output_tokens !== undefined) outputTokens = parsed.usage.output_tokens;
-          } catch {
-            // Ignore
+      // Only emit if real content was seen — same guard as Chat adapter.
+      if (hadRealContent) {
+        const push = this.push.bind(this);
+        // Process any remaining buffered line — extract usage before closing
+        if (lineBuffer.trim()) {
+          const line = lineBuffer.trim();
+          if (line.startsWith("data: ")) {
+            try {
+              const parsed = JSON.parse(line.slice(6).trim());
+              if (parsed?.usage?.input_tokens !== undefined) inputTokens = parsed.usage.input_tokens;
+              if (parsed?.usage?.output_tokens !== undefined) outputTokens = parsed.usage.output_tokens;
+            } catch {
+              // Ignore
+            }
           }
         }
+        emitMessageStart(push);
+        emitClosingEvents(push);
       }
-      emitMessageStart(push);
-      emitClosingEvents(push);
       callback();
     },
   });

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -834,6 +834,36 @@ export function compressOldTurns(body: Record<string, unknown>, keepTurns: numbe
   );
 }
 
+/** Strip thinking blocks from completed assistant turns, preserving only the last. */
+function stripThinkingFromCompletedTurns(messages: unknown[]): void {
+  if (!Array.isArray(messages) || messages.length < 2) return;
+
+  let lastAssistantIdx = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if ((messages[i] as any).role === "assistant") {
+      lastAssistantIdx = i;
+      break;
+    }
+  }
+  if (lastAssistantIdx < 0) return;
+
+  let stripped = 0;
+  for (let i = 0; i < messages.length; i++) {
+    if ((messages[i] as any).role !== "assistant" || i === lastAssistantIdx) continue;
+    const content = (messages[i] as any).content;
+    if (!Array.isArray(content)) continue;
+
+    const before = content.length;
+    (messages[i] as any).content = content.filter(
+      (block: any) => block.type !== "thinking"
+    );
+    stripped += before - (messages[i] as any).content.length;
+  }
+  if (stripped > 0) {
+    console.log(`[thinking-strip] Removed ${stripped} thinking block(s) from completed turns (preserved last assistant at idx ${lastAssistantIdx})`);
+  }
+}
+
 export function compressToolResults(body: Record<string, unknown>, limit: number): void {
   const messages = body.messages;
   if (!Array.isArray(messages)) return;
@@ -909,6 +939,7 @@ function applyTargetedReplacements(
     if (needsOrphanClean) cleanOrphanedToolMessages(mutable);
     if (provider.toolResultLimit) compressToolResults(mutable, provider.toolResultLimit);
     if (provider.compressOldTurns) compressOldTurns(mutable, provider.compressOldTurns);
+    if (Array.isArray(mutable.messages)) stripThinkingFromCompletedTurns(mutable.messages as unknown[]);
     if (provider.modelLimits) {
       const { maxOutputTokens } = provider.modelLimits;
       const requested = typeof mutable.max_tokens === "number" ? mutable.max_tokens : maxOutputTokens;
@@ -1134,6 +1165,10 @@ export async function forwardRequest(
 
           if (provider.compressOldTurns) {
             compressOldTurns(mutable, provider.compressOldTurns);
+          }
+
+          if (Array.isArray(mutable.messages)) {
+            stripThinkingFromCompletedTurns(mutable.messages as unknown[]);
           }
 
           if (provider.modelLimits) {
@@ -1665,6 +1700,7 @@ export async function forwardRequest(
     let sawContentBlockStop = false;
     let sawMessageStop = false;
     let sawRealContent = false; // true only when text_delta has non-empty text or tool_use appears
+    let sawThinkingContent = false; // true when thinking_delta appears (thinking-only is valid, not empty)
     let _rollingTail = "";
 
     // Snapshot of upstream state BEFORE any synthetic events are injected.
@@ -1760,6 +1796,10 @@ export async function forwardRequest(
               try {
                 const evt = JSON.parse(payload);
                 if (evt.type === "content_block_delta" && (
+                  evt.delta?.type === "thinking_delta" && evt.delta.thinking && evt.delta.thinking.length > 0
+                )) {
+                  sawThinkingContent = true;
+                } else if (evt.type === "content_block_delta" && (
                   evt.delta?.type === "text_delta" && evt.delta.text && evt.delta.text.length > 0
                 )) {
                   sawRealContent = true;
@@ -1774,11 +1814,12 @@ export async function forwardRequest(
       }
 
       // Empty response detection: check if this is an empty end_turn.
-      // sawRealContent only counts text_delta with actual text or tool_use.
-      // thinking_delta alone does NOT count — a thinking-only response is empty.
-      // Once we see message_stop without real content, flag as empty.
+      // sawRealContent counts text_delta with actual text or tool_use.
+      // sawThinkingContent counts thinking_delta — a thinking-only response is valid,
+      // NOT empty (the model chose to only reason without generating text).
+      // Only flag as empty when there's NO content at all (no text, no tool_use, no thinking).
       if (!streamDetectedEmpty) {
-        if (sawMessageStop && !sawRealContent && !(passThrough as any)._intentionalClose) {
+        if (sawMessageStop && !sawRealContent && !sawThinkingContent && !(passThrough as any)._intentionalClose) {
           // Stream completed without any real content (not a stall-handled close)
           console.warn(`[empty-response] Provider "${provider.name}" returned empty/malformed response (no real content) — flagging as empty`);
           streamDetectedEmpty = true;
@@ -1796,15 +1837,13 @@ export async function forwardRequest(
       if (!streamDetectedEmpty && sawMessageStart && !(passThrough as any)._intentionalClose) {
         // Pattern: message_delta with stop_reason but no real content.
         // A provider completing the message without ever sending content = empty.
-        if (chunkText.includes('"message_delta"') && chunkText.includes('"stop_reason"') && !sawRealContent) {
+        if (chunkText.includes('"message_delta"') && chunkText.includes('"stop_reason"') && !sawRealContent && !sawThinkingContent) {
           detectEarlyEmpty(`Provider "${provider.name}" sent message_delta with stop_reason but no real content`);
         }
       }
 
-      // Debug: dump first chunk to see actual SSE content
-      if (((passThrough as any)._bytesForwarded ?? 0) <= chunk.length) {
-        console.warn(`[tracking] First chunk (${chunk.length}b): ${chunkText.slice(0, 400)}`);
-      }
+      // Track chunk count for safeClose diagnostics
+      (passThrough as any)._chunkCount = ((passThrough as any)._chunkCount ?? 0) + 1;
 
       // Forward to ReadableStream — merged from handler 3 to avoid extra dispatch.
       if (enqueueChunk) enqueueChunk(chunk);
@@ -1959,24 +1998,26 @@ export async function forwardRequest(
         const safeClose = () => {
           if (controllerClosed) return;
           controllerClosed = true;
+          console.warn(`[safeClose] bytes=${(passThrough as any)._bytesForwarded} msgStart=${sawMessageStart} msgStop=${sawMessageStop} real=${sawRealContent} think=${sawThinkingContent} chunks=${(passThrough as any)._chunkCount} state=${ctx._streamState}`);
           // Zero-byte or no message_start: upstream returned an empty/malformed response.
           // Inject a complete synthetic SSE message so Claude Code gets a parseable
           // response instead of crashing on empty content.
           const bytes = (passThrough as any)._bytesForwarded ?? 0;
           const isStallHandled = !!(passThrough as any)._intentionalClose;
-          if ((bytes === 0 || !sawMessageStart || (sawMessageStop && !sawRealContent)) && !isStallHandled) {
+          if ((bytes === 0 || !sawMessageStart || (sawMessageStop && !sawRealContent && !sawThinkingContent)) && !isStallHandled) {
             // Zero-byte or upstream completed without real content.
             // Inject a complete synthetic SSE message so Claude Code gets a parseable
             // response instead of crashing on empty content.
             // Skip when _intentionalClose — stall/hedge handlers already wrote graceful
             // termination events; injecting more would corrupt the stream.
-            // Skip when sawRealContent — real content proves the stream was valid;
+            // Skip when sawRealContent or sawThinkingContent — real content proves the stream was valid;
             // !sawMessageStart with sawRealContent is a detection gap, not a malformed stream.
-            if (sawRealContent) {
-              console.warn(`[safeClose] Stream had real content but msgStart=${sawMessageStart} — likely detection gap, skipping error injection (requestId=${ctx.requestId}, bytes=${bytes})`);
+            // Thinking-only responses are valid — the model chose to reason without generating text.
+            if (sawRealContent || sawThinkingContent) {
+              console.warn(`[safeClose] Stream had content (real=${sawRealContent}, thinking=${sawThinkingContent}) but msgStart=${sawMessageStart} — likely detection gap, skipping error injection (requestId=${ctx.requestId}, bytes=${bytes})`);
               // Fall through to normal closing events below
             } else {
-            console.warn(`[safeClose] Empty/malformed stream: bytes=${bytes} msgStart=${sawMessageStart} realContent=${sawRealContent} stallHandled=${isStallHandled} requestId=${ctx.requestId} — injecting error message`);
+            console.warn(`[safeClose] Empty/malformed stream: bytes=${bytes} msgStart=${sawMessageStart} realContent=${sawRealContent} thinking=${sawThinkingContent} stallHandled=${isStallHandled} requestId=${ctx.requestId} — injecting error message`);
             const msgId = `msg_proxy_empty_${Date.now()}`;
             const errorChunks = [
               `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { id: msgId, type: "message", role: "assistant", model: "proxy", content: [], stop_reason: null, stop_sequence: null, usage: { input_tokens: 0, output_tokens: 0 } } })}\n\n`,
@@ -2070,11 +2111,16 @@ export async function forwardRequest(
         // Wire up the deferred enqueue — called from the merged data handler
         // instead of a separate listener, saving one EventEmitter dispatch per chunk.
         enqueueChunk = (chunk: Buffer) => {
-          if (ctx._streamState === "error" || ctx._streamState === "complete") return;
+          if (ctx._streamState === "error" || ctx._streamState === "complete") {
+            console.warn(`[enqueue-skip] state=${ctx._streamState}, chunk=${chunk.toString().slice(0, 60)}`);
+            return;
+          }
           if (sseBuffer) {
             sseBuffer.write(chunk);
           } else {
-            try { controller.enqueue(chunk); } catch { /* already closed */ }
+            try {
+              controller.enqueue(chunk);
+            } catch (e: any) { console.warn(`[enqueue-err] ${e.message}`); /* already closed */ }
           }
         };
         passThrough.on("end", () => {


### PR DESCRIPTION
## Summary

- **Root cause**: When GLM OpenAI endpoint returns an empty/interrupted stream (HTTP 200, no content), both the OpenAI→Anthropic adapter and proxy's `safeClose` handler inject skeleton Anthropic SSE events. The double-injection produces a malformed stream that Claude Code can't parse → "empty or malformed response (HTTP 200)".
- **Adapter fix**: Added `hadRealContent` gate — only emit `message_start` and closing events when actual content (text, thinking, tool_use) was processed. Empty streams emit nothing, letting proxy's empty-response detection return 502 and trigger fallback.
- **Proxy fix**: Added `sawThinkingContent` flag — thinking-only responses are valid and should not trigger error injection.
- **Bonus**: Added `stripThinkingFromCompletedTurns` to reduce context size by stripping thinking blocks from older assistant turns.

## Test plan

- [ ] Verify Claude Code sessions through ModelWeaver work normally (text, tool use, thinking)
- [ ] Verify empty/upstream-drop responses trigger 502 fallback instead of malformed stream
- [ ] Check `[safeClose]` log entries show correct `think=true` for thinking-only responses