### PR TITLE
fix: launchd auto-start runs monitor directly

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -393,8 +393,9 @@ async function reloadLaunchdService(): Promise<void> {
     );
     if (existsSync(plistPath)) {
       const { execFileSync } = await import("node:child_process");
+      try { execFileSync("launchctl", ["unload", plistPath], { stdio: "pipe" }); } catch { /* not loaded */ }
       execFileSync("launchctl", ["load", plistPath], { stdio: "pipe" });
-      console.warn("[daemon] Reloaded launchd service — KeepAlive uses PathState (won't restart if entry script is missing)");
+      console.warn("[daemon] Reloaded launchd service (unload + load)");
     }
   } catch {
     // Not macOS or plist missing — skip

--- a/src/service-darwin.ts
+++ b/src/service-darwin.ts
@@ -26,7 +26,7 @@ function getPlistContent(): string {
   <array>
     <string>${process.execPath}</string>
     <string>${nodePath}</string>
-    <string>start</string>
+    <string>--monitor</string>
   </array>
   <key>KeepAlive</key>
   <dict>
@@ -84,7 +84,7 @@ export function install(): void {
     console.log(`  Try manually: launchctl load ${PLIST_PATH}`);
   }
 
-  console.log(`  Auto-starts on login and auto-restarts if stopped (KeepAlive gated by entry script existence)`);
+  console.log(`  Auto-starts on login and auto-restarts if stopped (runs monitor directly via launchd)`);
   console.log(`  Logs: ${LOG_DIR}/stdout.log and ${LOG_DIR}/stderr.log`);
 }
 


### PR DESCRIPTION
## Summary
- Changed plist `ProgramArguments` from `start` to `--monitor` so launchd manages the long-running supervisor directly
- Fixed `reloadLaunchdService()` to unload+load (force reload) instead of just load
- Root cause of "API Error: empty or malformed response (HTTP 200)" — launchd respawn storm from one-shot `start` was killing workers mid-request

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds
- [x] `node dist/index.js install` regenerates plist with `--monitor`
- [x] `launchctl print` shows `state = running`, `runs = 1`
- [x] Monitor auto-spawns worker on port free
- [x] Proxy serves requests normally